### PR TITLE
feat: Move children to container; add expand flag

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,30 +19,10 @@ class ExampleApp extends StatefulWidget {
 
 class _ExampleAppState extends State<ExampleApp> {
   bool hovered = false;
+  bool hidden = false;
 
-  final controller1 = ResizableController(
-    data: const [
-      ResizableChild(
-        startingRatio: ratio1,
-        minSize: 150,
-      ),
-      ResizableChild(
-        startingRatio: ratio2,
-        maxSize: 500,
-      ),
-    ],
-  );
-
-  final controller2 = ResizableController(
-    data: const [
-      ResizableChild(
-        startingRatio: ratio3,
-      ),
-      ResizableChild(
-        startingRatio: ratio4,
-      ),
-    ],
-  );
+  final controller1 = ResizableController();
+  final controller2 = ResizableController();
 
   Axis direction = Axis.horizontal;
 
@@ -74,7 +54,7 @@ class _ExampleAppState extends State<ExampleApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      theme: ThemeData.light(),
+      theme: ThemeData.light(useMaterial3: true),
       home: Scaffold(
         appBar: AppBar(
           title: const Text('Example ResizableContainer'),
@@ -82,10 +62,15 @@ class _ExampleAppState extends State<ExampleApp> {
             ElevatedButton(
               onPressed: () {
                 controller1.ratios = [ratio1, ratio2];
-                controller2.ratios = [ratio3, ratio4];
+                if (!hidden) {
+                  controller2.ratios = [ratio3, ratio4];
+                } else {
+                  controller2.ratios = [null];
+                }
               },
               child: const Text("Reset ratios"),
             ),
+            const SizedBox(width: 10),
             ElevatedButton(
               onPressed: () {
                 final newDirection = direction == Axis.horizontal
@@ -98,6 +83,12 @@ class _ExampleAppState extends State<ExampleApp> {
                   ? const Text('Vertical')
                   : const Text('Horizontal'),
             ),
+            const SizedBox(width: 10),
+            ElevatedButton(
+              onPressed: () => setState(() => hidden = !hidden),
+              child: Text(hidden ? 'Show Child B' : 'Hide Child B'),
+            ),
+            const SizedBox(width: 10),
           ],
         ),
         body: SafeArea(
@@ -114,45 +105,61 @@ class _ExampleAppState extends State<ExampleApp> {
               onHoverExit: () => setState(() => hovered = false),
             ),
             children: [
-              LayoutBuilder(
-                builder: (context, constraints) => Center(
-                  child: direction == Axis.horizontal
-                      ? Text(
-                          'Left pane: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                          textAlign: TextAlign.center,
-                        )
-                      : Text(
-                          'Top pane: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                          textAlign: TextAlign.center,
-                        ),
+              ResizableChild(
+                startingRatio: ratio1,
+                minSize: 150,
+                child: LayoutBuilder(
+                  builder: (context, constraints) => Center(
+                    child: direction == Axis.horizontal
+                        ? Text(
+                            'Left pane: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
+                            textAlign: TextAlign.center,
+                          )
+                        : Text(
+                            'Top pane: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
+                            textAlign: TextAlign.center,
+                          ),
+                  ),
                 ),
               ),
-              ResizableContainer(
-                controller: controller2,
-                divider: const ResizableDivider(
-                  color: Colors.green,
+              ResizableChild(
+                startingRatio: ratio2,
+                maxSize: 500,
+                child: ResizableContainer(
+                  controller: controller2,
+                  divider: const ResizableDivider(
+                    color: Colors.green,
+                  ),
+                  direction: direction == Axis.horizontal
+                      ? Axis.vertical
+                      : Axis.horizontal,
+                  children: [
+                    ResizableChild(
+                      startingRatio: ratio3,
+                      child: LayoutBuilder(
+                        builder: (context, constraints) => Center(
+                          child: Text(
+                            'Nested Child A: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ),
+                    ),
+                    if (!hidden) ...[
+                      ResizableChild(
+                        startingRatio: ratio4,
+                        child: LayoutBuilder(
+                          builder: (context, constraints) => Center(
+                            child: Text(
+                              'Nested Child B: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
-                direction: direction == Axis.horizontal
-                    ? Axis.vertical
-                    : Axis.horizontal,
-                children: [
-                  LayoutBuilder(
-                    builder: (context, constraints) => Center(
-                      child: Text(
-                        'Nested Child A: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                  ),
-                  LayoutBuilder(
-                    builder: (context, constraints) => Center(
-                      child: Text(
-                        'Nested Child B: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                  ),
-                ],
               ),
             ],
           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -115,24 +115,15 @@ class _ExampleAppState extends State<ExampleApp> {
                 startingRatio: ratio1,
                 minSize: 150,
                 child: LayoutBuilder(
-                  builder: (context, constraints) => DecoratedBox(
-                    decoration: const BoxDecoration(
+                  builder: (context, constraints) {
+                    return ExpandedChild(
                       color: Colors.green,
-                    ),
-                    child: SizedBox.expand(
-                      child: Center(
-                        child: direction == Axis.horizontal
-                            ? Text(
-                                'Left pane: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                                textAlign: TextAlign.center,
-                              )
-                            : Text(
-                                'Top pane: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                                textAlign: TextAlign.center,
-                              ),
-                      ),
-                    ),
-                  ),
+                      constraints: constraints,
+                      label: direction == Axis.horizontal
+                          ? 'Left Pane'
+                          : 'Right Pane',
+                    );
+                  },
                 ),
               ),
               ResizableChild(
@@ -151,40 +142,26 @@ class _ExampleAppState extends State<ExampleApp> {
                       expand: expand,
                       startingRatio: ratio3,
                       child: LayoutBuilder(
-                        builder: (context, constraints) => Center(
-                          child: DecoratedBox(
-                            decoration: const BoxDecoration(
-                              color: Colors.pink,
-                            ),
-                            child: SizedBox.expand(
-                              child: Center(
-                                child: Text(
-                                  'Nested Child A: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                                  textAlign: TextAlign.center,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
+                        builder: (context, constraints) {
+                          return ExpandedChild(
+                            color: Colors.pink,
+                            constraints: constraints,
+                            label: 'Nested Child A',
+                          );
+                        },
                       ),
                     ),
                     if (!hidden) ...[
                       ResizableChild(
                         startingRatio: ratio4,
                         child: LayoutBuilder(
-                          builder: (context, constraints) => Center(
-                            child: DecoratedBox(
-                              decoration: const BoxDecoration(
-                                color: Colors.amber,
-                              ),
-                              child: Center(
-                                child: Text(
-                                  'Nested Child B: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                                  textAlign: TextAlign.center,
-                                ),
-                              ),
-                            ),
-                          ),
+                          builder: (context, constraints) {
+                            return ExpandedChild(
+                              label: 'Nested Child B',
+                              color: Colors.amber,
+                              constraints: constraints,
+                            );
+                          },
                         ),
                       ),
                     ],
@@ -192,6 +169,39 @@ class _ExampleAppState extends State<ExampleApp> {
                 ),
               ),
             ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class ExpandedChild extends StatelessWidget {
+  const ExpandedChild({
+    super.key,
+    required this.color,
+    required this.constraints,
+    required this.label,
+  });
+
+  final Color color;
+  final BoxConstraints constraints;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final height = constraints.maxHeight.toStringAsFixed(2);
+    final width = constraints.maxWidth.toStringAsFixed(2);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: color,
+      ),
+      child: SizedBox.expand(
+        child: Center(
+          child: Text(
+            '$label ($height x $width)',
+            textAlign: TextAlign.center,
           ),
         ),
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,11 +22,11 @@ class _ExampleAppState extends State<ExampleApp> {
 
   final controller1 = ResizableController(
     data: const [
-      ResizableChildData(
+      ResizableChild(
         startingRatio: ratio1,
         minSize: 150,
       ),
-      ResizableChildData(
+      ResizableChild(
         startingRatio: ratio2,
         maxSize: 500,
       ),
@@ -35,10 +35,10 @@ class _ExampleAppState extends State<ExampleApp> {
 
   final controller2 = ResizableController(
     data: const [
-      ResizableChildData(
+      ResizableChild(
         startingRatio: ratio3,
       ),
-      ResizableChildData(
+      ResizableChild(
         startingRatio: ratio4,
       ),
     ],

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -135,7 +135,7 @@ class _ExampleAppState extends State<ExampleApp> {
                       : Axis.horizontal,
                   children: [
                     ResizableChild(
-                      startingRatio: ratio3,
+                      startingRatio: hidden ? null : ratio3,
                       child: LayoutBuilder(
                         builder: (context, constraints) => Center(
                           child: Text(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -135,7 +135,8 @@ class _ExampleAppState extends State<ExampleApp> {
                       : Axis.horizontal,
                   children: [
                     ResizableChild(
-                      startingRatio: hidden ? null : ratio3,
+                      expand: true,
+                      startingRatio: ratio3,
                       child: LayoutBuilder(
                         builder: (context, constraints) => Center(
                           child: Text(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,12 +18,12 @@ class ExampleApp extends StatefulWidget {
 }
 
 class _ExampleAppState extends State<ExampleApp> {
-  bool hovered = false;
-  bool hidden = false;
-
   final controller1 = ResizableController();
   final controller2 = ResizableController();
 
+  bool hovered = false;
+  bool hidden = false;
+  bool expand = true;
   Axis direction = Axis.horizontal;
 
   @override
@@ -89,6 +89,12 @@ class _ExampleAppState extends State<ExampleApp> {
               child: Text(hidden ? 'Show Child B' : 'Hide Child B'),
             ),
             const SizedBox(width: 10),
+            const Text('Auto-expand?'),
+            Switch(
+              value: expand,
+              onChanged: (_) => setState(() => expand = !expand),
+            ),
+            const SizedBox(width: 10),
           ],
         ),
         body: SafeArea(
@@ -109,16 +115,23 @@ class _ExampleAppState extends State<ExampleApp> {
                 startingRatio: ratio1,
                 minSize: 150,
                 child: LayoutBuilder(
-                  builder: (context, constraints) => Center(
-                    child: direction == Axis.horizontal
-                        ? Text(
-                            'Left pane: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                            textAlign: TextAlign.center,
-                          )
-                        : Text(
-                            'Top pane: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                            textAlign: TextAlign.center,
-                          ),
+                  builder: (context, constraints) => DecoratedBox(
+                    decoration: const BoxDecoration(
+                      color: Colors.green,
+                    ),
+                    child: SizedBox.expand(
+                      child: Center(
+                        child: direction == Axis.horizontal
+                            ? Text(
+                                'Left pane: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
+                                textAlign: TextAlign.center,
+                              )
+                            : Text(
+                                'Top pane: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
+                                textAlign: TextAlign.center,
+                              ),
+                      ),
+                    ),
                   ),
                 ),
               ),
@@ -135,13 +148,22 @@ class _ExampleAppState extends State<ExampleApp> {
                       : Axis.horizontal,
                   children: [
                     ResizableChild(
-                      expand: true,
+                      expand: expand,
                       startingRatio: ratio3,
                       child: LayoutBuilder(
                         builder: (context, constraints) => Center(
-                          child: Text(
-                            'Nested Child A: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                            textAlign: TextAlign.center,
+                          child: DecoratedBox(
+                            decoration: const BoxDecoration(
+                              color: Colors.pink,
+                            ),
+                            child: SizedBox.expand(
+                              child: Center(
+                                child: Text(
+                                  'Nested Child A: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            ),
                           ),
                         ),
                       ),
@@ -151,9 +173,16 @@ class _ExampleAppState extends State<ExampleApp> {
                         startingRatio: ratio4,
                         child: LayoutBuilder(
                           builder: (context, constraints) => Center(
-                            child: Text(
-                              'Nested Child B: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
-                              textAlign: TextAlign.center,
+                            child: DecoratedBox(
+                              decoration: const BoxDecoration(
+                                color: Colors.amber,
+                              ),
+                              child: Center(
+                                child: Text(
+                                  'Nested Child B: ${constraints.maxHeight.toStringAsFixed(2)} x ${constraints.maxWidth.toStringAsFixed(2)}',
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
                             ),
                           ),
                         ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  decimal:
+    dependency: transitive
+    description:
+      name: decimal
+      sha256: "24a261d5d5c87e86c7651c417a5dbdf8bcd7080dd592533910e8d0505a279f21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
   fake_async:
     dependency: transitive
     description:
@@ -76,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "2.0.0+beta.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -146,6 +154,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: ba58e9e18df9abde280e8b10051e4bce85091e41e8e7e411b6cde2e738d357cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/flutter_resizable_container.dart
+++ b/lib/flutter_resizable_container.dart
@@ -2,5 +2,5 @@ library flutter_resizable_container;
 
 export 'src/resizable_container.dart';
 export 'src/resizable_controller.dart';
-export 'src/resizable_child_data.dart';
+export 'src/resizable_child.dart';
 export 'src/resizable_divider.dart';

--- a/lib/flutter_resizable_container.dart
+++ b/lib/flutter_resizable_container.dart
@@ -1,6 +1,6 @@
 library flutter_resizable_container;
 
 export 'src/resizable_container.dart';
-export 'src/resizable_controller.dart' show ResizableController;
+export 'src/resizable_controller.dart';
 export 'src/resizable_child.dart';
 export 'src/resizable_divider.dart';

--- a/lib/flutter_resizable_container.dart
+++ b/lib/flutter_resizable_container.dart
@@ -1,6 +1,6 @@
 library flutter_resizable_container;
 
 export 'src/resizable_container.dart';
-export 'src/resizable_controller.dart';
+export 'src/resizable_controller.dart' show ResizableController;
 export 'src/resizable_child.dart';
 export 'src/resizable_divider.dart';

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -36,16 +36,24 @@ class ResizableChild {
       'startingRatio: $startingRatio, '
       'maxSize: $maxSize, '
       'minSize: $minSize, '
-      'child: $child)';
+      'child: $child, '
+      'expand: $expand)';
 
   @override
   operator ==(Object other) =>
       other is ResizableChild &&
+      other.expand == expand &&
       other.startingRatio == startingRatio &&
       other.maxSize == maxSize &&
       other.minSize == minSize &&
       other.child.runtimeType == child.runtimeType;
 
   @override
-  int get hashCode => Object.hash(startingRatio, maxSize, minSize, child);
+  int get hashCode => Object.hash(
+        expand,
+        startingRatio,
+        maxSize,
+        minSize,
+        child,
+      );
 }

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -1,7 +1,7 @@
 /// Controls the sizing parameters for the [child] Widget.
-class ResizableChildData {
-  /// Create a new instance of the [ResizableChildData] class.
-  const ResizableChildData({
+class ResizableChild {
+  /// Create a new instance of the [ResizableChild] class.
+  const ResizableChild({
     this.startingRatio,
     this.maxSize,
     this.minSize,

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -5,23 +5,28 @@ class ResizableChild {
   /// Create a new instance of the [ResizableChild] class.
   const ResizableChild({
     required this.child,
-    this.startingRatio,
+    this.expand = false,
     this.maxSize,
     this.minSize,
+    this.startingRatio,
   }) : assert(
           startingRatio == null || (startingRatio >= 0 && startingRatio <= 1),
           'The starting ratio must be null or between 0 and 1, inclusive',
         );
 
-  /// The starting size (as a ratio of available space) of the
-  /// corresponding widget.
-  final double? startingRatio;
+  /// Whether this child should expand to fill empty space, even if it extends
+  /// beyond its [startingRatio].
+  final bool expand;
 
   /// The (optional) maximum size (in px) of this child Widget.
   final double? maxSize;
 
   /// The (optional) minimum size (in px) of this child Widget.
   final double? minSize;
+
+  /// The starting size (as a ratio of available space) of the
+  /// corresponding widget.
+  final double? startingRatio;
 
   /// The child [Widget]
   final Widget child;

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -39,7 +39,7 @@ class ResizableChild {
       other.startingRatio == startingRatio &&
       other.maxSize == maxSize &&
       other.minSize == minSize &&
-      other.child == child;
+      other.child.runtimeType == child.runtimeType;
 
   @override
   int get hashCode => Object.hash(startingRatio, maxSize, minSize, child);

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -1,7 +1,10 @@
+import 'package:flutter/material.dart';
+
 /// Controls the sizing parameters for the [child] Widget.
 class ResizableChild {
   /// Create a new instance of the [ResizableChild] class.
   const ResizableChild({
+    required this.child,
     this.startingRatio,
     this.maxSize,
     this.minSize,
@@ -20,9 +23,24 @@ class ResizableChild {
   /// The (optional) minimum size (in px) of this child Widget.
   final double? minSize;
 
+  /// The child [Widget]
+  final Widget child;
+
   @override
   String toString() => 'ResizableChildData('
       'startingRatio: $startingRatio, '
       'maxSize: $maxSize, '
-      'minSize: $minSize)';
+      'minSize: $minSize, '
+      'child: $child)';
+
+  @override
+  operator ==(Object other) =>
+      other is ResizableChild &&
+      other.startingRatio == startingRatio &&
+      other.maxSize == maxSize &&
+      other.minSize == minSize &&
+      other.child == child;
+
+  @override
+  int get hashCode => Object.hash(startingRatio, maxSize, minSize, child);
 }

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -47,18 +47,18 @@ class _ResizableContainerState extends State<ResizableContainer> {
 
   @override
   void didUpdateWidget(covariant ResizableContainer oldWidget) {
-    final isSameLength = oldWidget.children.length == widget.children.length;
-    final areChildrenEqual = oldWidget.children.indexed.every(
-      (element) {
-        final (index, child) = element;
-        return child == widget.children[index];
-      },
-    );
+    bool compareChildren() => oldWidget.children.indexed.every(
+          (element) {
+            final (index, child) = element;
+            return widget.children[index] == child;
+          },
+        );
 
-    final hasChanges = !isSameLength || !areChildrenEqual;
+    final isSameLength = oldWidget.children.length == widget.children.length;
+    final hasChanges = !isSameLength || !compareChildren();
 
     if (hasChanges) {
-      widget.controller.setChildren(widget.children);
+      widget.controller.updateChildren(widget.children);
     }
 
     super.didUpdateWidget(oldWidget);

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 import 'package:flutter_resizable_container/src/extensions/box_constraints_ext.dart';
 import 'package:flutter_resizable_container/src/resizable_container_divider.dart';
+import 'package:flutter_resizable_container/src/resizable_controller.dart';
 
 /// A container that holds multiple child [Widget]s that can be resized.
 ///

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 import 'package:flutter_resizable_container/src/extensions/box_constraints_ext.dart';
 import 'package:flutter_resizable_container/src/resizable_container_divider.dart';
-import 'package:flutter_resizable_container/src/resizable_controller.dart';
 
 /// A container that holds multiple child [Widget]s that can be resized.
 ///
@@ -43,20 +42,23 @@ class _ResizableContainerState extends State<ResizableContainer> {
   void initState() {
     super.initState();
 
-    ResizableControllerManager.setChildren(widget.controller, widget.children);
+    widget.controller.setChildren(widget.children);
   }
 
   @override
   void didUpdateWidget(covariant ResizableContainer oldWidget) {
-    final hasChanges = oldWidget.children.indexed.any((element) {
-      return widget.children[element.$1] != element.$2;
-    });
+    final isSameLength = oldWidget.children.length == widget.children.length;
+    final areChildrenEqual = oldWidget.children.indexed.every(
+      (element) {
+        final (index, child) = element;
+        return child == widget.children[index];
+      },
+    );
+
+    final hasChanges = !isSameLength || !areChildrenEqual;
 
     if (hasChanges) {
-      ResizableControllerManager.setChildren(
-        widget.controller,
-        widget.children,
-      );
+      widget.controller.setChildren(widget.children);
     }
 
     super.didUpdateWidget(oldWidget);

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -21,7 +21,8 @@ class ResizableContainer extends StatefulWidget {
     ResizableDivider? divider,
   }) : divider = divider ?? const ResizableDivider();
 
-  /// A list of resizable [Widget]s.
+  /// A list of resizable [ResizableChild] containing the child [Widget]s and
+  /// their sizing configuration.
   final List<ResizableChild> children;
 
   /// The controller that will be used to manage programmatic resizing of the children.
@@ -47,7 +48,11 @@ class _ResizableContainerState extends State<ResizableContainer> {
 
   @override
   void didUpdateWidget(covariant ResizableContainer oldWidget) {
-    if (oldWidget.children.length != widget.children.length) {
+    final hasChanges = oldWidget.children.indexed.any((element) {
+      return widget.children[element.$1] != element.$2;
+    });
+
+    if (hasChanges) {
       ResizableControllerManager.setChildren(
         widget.controller,
         widget.children,

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -7,25 +7,21 @@ import 'package:flutter_resizable_container/src/resizable_container_divider.dart
 ///
 /// Dividing lines will be added between each child. Dragging the dividers
 /// will resize the children along the [direction] axis.
-class ResizableContainer extends StatelessWidget {
+class ResizableContainer extends StatefulWidget {
   /// Creates a new [ResizableContainer] with the given [direction] and list
   /// of [children] Widgets.
   ///
   /// The sum of the [children]'s starting ratios must be equal to 1.0.
-  ResizableContainer({
+  const ResizableContainer({
     super.key,
     required this.children,
     required this.controller,
     required this.direction,
     ResizableDivider? divider,
-  })  : divider = divider ?? const ResizableDivider(),
-        assert(
-          children.length == controller.data.length,
-          'Controller must have as many data items as there are children.',
-        );
+  }) : divider = divider ?? const ResizableDivider();
 
   /// A list of resizable [Widget]s.
-  final List<Widget> children;
+  final List<ResizableChild> children;
 
   /// The controller that will be used to manage programmatic resizing of the children.
   final ResizableController controller;
@@ -37,19 +33,43 @@ class ResizableContainer extends StatelessWidget {
   final ResizableDivider divider;
 
   @override
+  State<ResizableContainer> createState() => _ResizableContainerState();
+}
+
+class _ResizableContainerState extends State<ResizableContainer> {
+  @override
+  void initState() {
+    super.initState();
+
+    ResizableControllerManager.setChildren(widget.controller, widget.children);
+  }
+
+  @override
+  void didUpdateWidget(covariant ResizableContainer oldWidget) {
+    if (oldWidget.children.length != widget.children.length) {
+      ResizableControllerManager.setChildren(
+        widget.controller,
+        widget.children,
+      );
+    }
+
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        controller.availableSpace = _getAvailableSpace(constraints);
+        widget.controller.availableSpace = _getAvailableSpace(constraints);
 
         return AnimatedBuilder(
-          animation: controller,
+          animation: widget.controller,
           builder: (context, _) {
             return Flex(
               crossAxisAlignment: CrossAxisAlignment.stretch,
-              direction: direction,
+              direction: widget.direction,
               children: [
-                for (var i = 0; i < children.length; i++) ...[
+                for (var i = 0; i < widget.children.length; i++) ...[
                   // build the child
                   Builder(
                     builder: (context) {
@@ -68,15 +88,16 @@ class ResizableContainer extends StatelessWidget {
                       return SizedBox(
                         height: height,
                         width: width,
-                        child: children[i],
+                        child: widget.children[i].child,
                       );
                     },
                   ),
-                  if (i < children.length - 1) ...[
+                  if (i < widget.children.length - 1) ...[
                     ResizableContainerDivider(
-                      config: divider,
-                      direction: direction,
-                      onResizeUpdate: (delta) => controller.adjustChildSize(
+                      config: widget.divider,
+                      direction: widget.direction,
+                      onResizeUpdate: (delta) =>
+                          widget.controller.adjustChildSize(
                         index: i,
                         delta: delta,
                       ),
@@ -92,8 +113,8 @@ class ResizableContainer extends StatelessWidget {
   }
 
   double _getAvailableSpace(BoxConstraints constraints) {
-    final totalSpace = constraints.maxForDirection(direction);
-    final dividerSpace = (children.length - 1) * divider.size;
+    final totalSpace = constraints.maxForDirection(widget.direction);
+    final dividerSpace = (widget.children.length - 1) * widget.divider.size;
     return totalSpace - dividerSpace;
   }
 
@@ -104,6 +125,6 @@ class ResizableContainer extends StatelessWidget {
   }) {
     return direction != direction
         ? constraints.maxForDirection(direction)
-        : controller.sizes[index];
+        : widget.controller.sizes[index];
   }
 }

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -22,6 +22,18 @@ class ResizableController with ChangeNotifier {
     _calculateChildSizes(_availableSpace);
   }
 
+  /// Updates the list of [children] and re-calculates their sizes.
+  ///
+  /// This should only be used internally.
+  void updateChildren(List<ResizableChild> children) {
+    _children = children;
+
+    final availableSpace = _availableSpace;
+    _availableSpace = -1;
+    _calculateChildSizes(availableSpace);
+    _availableSpace = availableSpace;
+  }
+
   /// The sizes in pixels of each child.
   List<double> get sizes => _sizes;
 

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -1,10 +1,9 @@
 import "dart:math";
 
 import 'package:flutter/material.dart';
+import "package:flutter_resizable_container/flutter_resizable_container.dart";
 import "package:flutter_resizable_container/src/extensions/iterable_ext.dart";
 
-import "resizable_child_data.dart";
-import "resizable_container.dart";
 import "utils.dart";
 
 /// A controller to provide a programmatic interface to a [ResizableContainer].
@@ -27,9 +26,9 @@ class ResizableController with ChangeNotifier {
   double _nullRatioSpace = 0;
   List<double> _sizes = [];
 
-  /// A list of [ResizableChildData] objects that control the sizing parameters
+  /// A list of [ResizableChild] objects that control the sizing parameters
   /// for the list of children of a [ResizableContainer].
-  final List<ResizableChildData> data;
+  final List<ResizableChild> data;
 
   /// The sizes in pixels of each child.
   List<double> get sizes => _sizes;
@@ -65,7 +64,7 @@ class ResizableController with ChangeNotifier {
     notifyListeners();
   }
 
-  /// The ratios of all the children, like [ResizableChildData.startingRatio].
+  /// The ratios of all the children, like [ResizableChild.startingRatio].
   List<double> get ratios => [
         for (final size in sizes) size / _availableSpace,
       ];

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -21,9 +21,9 @@ class ResizableControllerManager {
       );
     }
 
-    controller._children = children;
-
     final availableSpace = controller._availableSpace;
+
+    controller._children = children;
     controller._availableSpace = -1;
     controller._calculateChildSizes(availableSpace);
   }

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -38,7 +38,7 @@ class ResizableController with ChangeNotifier {
   }
 
   void _calculateChildSizes(double availableSpace) {
-    if (availableSpace == -1) {
+    if (_availableSpace == -1) {
       _nullRatioSpace = _calculateSpaceForNullStartingRatios(availableSpace);
       _sizes = _calculateSizesBasedOnStartingRatios(availableSpace).toList();
     } else {

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -113,12 +113,32 @@ class ResizableController with ChangeNotifier {
     notifyListeners();
   }
 
-  Iterable<double> _calculateSizesBasedOnStartingRatios(
+  List<double> _calculateSizesBasedOnStartingRatios(
     double availableSpace,
-  ) sync* {
-    for (final datum in _children) {
-      yield (datum.startingRatio ?? _nullRatioSpace) * availableSpace;
+  ) {
+    final sizes = [
+      for (final child in _children) ...[
+        (child.startingRatio ?? _nullRatioSpace) * availableSpace,
+      ],
+    ];
+
+    final sum = sizes.sum();
+    if (sum < availableSpace) {
+      final expandableCount = _children.where((child) => child.expand).length;
+
+      if (expandableCount > 0) {
+        final difference = availableSpace - sum;
+        final spacePerExpandable = difference / expandableCount;
+
+        for (var i = 0; i < _children.length; i++) {
+          if (_children[i].expand) {
+            sizes[i] += spacePerExpandable;
+          }
+        }
+      }
     }
+
+    return sizes;
   }
 
   Iterable<double> _calculateSizesBasedOnCurrentRatios(

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -52,7 +52,7 @@ class ResizableController with ChangeNotifier {
   void _calculateChildSizes(double availableSpace) {
     if (_availableSpace == -1) {
       _nullRatioSpace = _calculateSpaceForNullStartingRatios(availableSpace);
-      _sizes = _calculateSizesBasedOnStartingRatios(availableSpace).toList();
+      _sizes = _calculateSizesBasedOnStartingRatios(availableSpace);
     } else {
       _sizes = _calculateSizesBasedOnCurrentRatios(availableSpace).toList();
     }

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -178,13 +178,13 @@ class ResizableController with ChangeNotifier {
     final ratios = _children.map((datum) => datum.startingRatio);
     final nonNullRatios = ratios.whereType<double>().toList();
     final ratioSum = sum(nonNullRatios).toDouble();
-    final remainingRatioSpace = 1.0 - ratioSum;
+    final remainingRatioSpace = (Decimal.one - Decimal.parse('$ratioSum'));
     final nullRatiosCount = ratios.length - nonNullRatios.length;
 
     if (nullRatiosCount == 0) {
       return 0.0;
     }
 
-    return remainingRatioSpace / nullRatiosCount;
+    return (remainingRatioSpace / Decimal.fromInt(nullRatiosCount)).toDouble();
   }
 }

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -6,12 +6,12 @@ import "package:flutter_resizable_container/src/extensions/iterable_ext.dart";
 
 import "utils.dart";
 
-/// A controller to provide a programmatic interface to a [ResizableContainer].
-class ResizableController with ChangeNotifier {
-  ResizableController({
-    required this.data,
-  }) {
-    final ratioSum = data.map((datum) => datum.startingRatio ?? 0).sum();
+class ResizableControllerManager {
+  static void setChildren(
+    ResizableController controller,
+    List<ResizableChild> children,
+  ) {
+    final ratioSum = children.map((datum) => datum.startingRatio ?? 0).sum();
 
     if (ratioSum > 1) {
       throw ArgumentError.value(
@@ -20,15 +20,21 @@ class ResizableController with ChangeNotifier {
         'The sum of all startingRatios must be less than or equal to 1.0',
       );
     }
-  }
 
+    controller._children = children;
+
+    final availableSpace = controller._availableSpace;
+    controller._availableSpace = -1;
+    controller._calculateChildSizes(availableSpace);
+  }
+}
+
+/// A controller to provide a programmatic interface to a [ResizableContainer].
+class ResizableController with ChangeNotifier {
   double _availableSpace = -1;
   double _nullRatioSpace = 0;
   List<double> _sizes = [];
-
-  /// A list of [ResizableChild] objects that control the sizing parameters
-  /// for the list of children of a [ResizableContainer].
-  final List<ResizableChild> data;
+  List<ResizableChild> _children = const [];
 
   /// The sizes in pixels of each child.
   List<double> get sizes => _sizes;
@@ -39,15 +45,19 @@ class ResizableController with ChangeNotifier {
       return;
     }
 
-    if (_availableSpace == -1) {
-      _nullRatioSpace = _calculateSpaceForNullStartingRatios(value);
-      _sizes = _calculateSizesBasedOnStartingRatios(value).toList();
-    } else {
-      _sizes = _calculateSizesBasedOnCurrentRatios(value).toList();
-    }
+    _calculateChildSizes(value);
 
     _availableSpace = value;
     notifyListeners();
+  }
+
+  void _calculateChildSizes(double availableSpace) {
+    if (_availableSpace == -1) {
+      _nullRatioSpace = _calculateSpaceForNullStartingRatios(availableSpace);
+      _sizes = _calculateSizesBasedOnStartingRatios(availableSpace).toList();
+    } else {
+      _sizes = _calculateSizesBasedOnCurrentRatios(availableSpace).toList();
+    }
   }
 
   /// Adjust the size of the child widget at [index] by the [delta] amount.
@@ -71,7 +81,7 @@ class ResizableController with ChangeNotifier {
 
   /// Programmatically set the ratios on the children. See [ratios] to get their current ratios.
   set ratios(List<double?> values) {
-    if (values.length != data.length) {
+    if (values.length != _children.length) {
       throw ArgumentError('Must contain a ratio for every child');
     }
 
@@ -108,7 +118,7 @@ class ResizableController with ChangeNotifier {
   Iterable<double> _calculateSizesBasedOnStartingRatios(
     double availableSpace,
   ) sync* {
-    for (final datum in data) {
+    for (final datum in _children) {
       yield (datum.startingRatio ?? _nullRatioSpace) * availableSpace;
     }
   }
@@ -127,9 +137,9 @@ class ResizableController with ChangeNotifier {
     required double delta,
   }) {
     final currentSize = sizes[index];
-    final minCurrentSize = data[index].minSize ?? 0;
+    final minCurrentSize = _children[index].minSize ?? 0;
     final adjacentSize = sizes[index + 1];
-    final maxAdjacentSize = data[index + 1].maxSize ?? double.infinity;
+    final maxAdjacentSize = _children[index + 1].maxSize ?? double.infinity;
     final maxCurrentDelta = currentSize - minCurrentSize;
     final maxAdjacentDelta = maxAdjacentSize - adjacentSize;
     final maxDelta = min(maxCurrentDelta, maxAdjacentDelta);
@@ -147,9 +157,9 @@ class ResizableController with ChangeNotifier {
     required double delta,
   }) {
     final currentSize = sizes[index];
-    final maxCurrentSize = data[index].maxSize ?? double.infinity;
+    final maxCurrentSize = _children[index].maxSize ?? double.infinity;
     final adjacentSize = sizes[index + 1];
-    final minAdjacentSize = data[index + 1].minSize ?? 0;
+    final minAdjacentSize = _children[index + 1].minSize ?? 0;
     final maxAvailableSpace = min(maxCurrentSize, _availableSpace);
     final maxCurrentDelta = maxAvailableSpace - currentSize;
     final maxAdjacentDelta = adjacentSize - minAdjacentSize;
@@ -165,7 +175,7 @@ class ResizableController with ChangeNotifier {
   // calculate the ratio of available space alloted to children without a
   // specified starting ratio.
   double _calculateSpaceForNullStartingRatios(double availableSpace) {
-    final ratios = data.map((datum) => datum.startingRatio);
+    final ratios = _children.map((datum) => datum.startingRatio);
     final nonNullRatios = ratios.whereType<double>().toList();
     final ratioSum = sum(nonNullRatios).toDouble();
     final remainingRatioSpace = 1.0 - ratioSum;

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -1,33 +1,11 @@
 import "dart:math";
 
+import "package:decimal/decimal.dart";
 import 'package:flutter/material.dart';
 import "package:flutter_resizable_container/flutter_resizable_container.dart";
 import "package:flutter_resizable_container/src/extensions/iterable_ext.dart";
 
 import "utils.dart";
-
-class ResizableControllerManager {
-  static void setChildren(
-    ResizableController controller,
-    List<ResizableChild> children,
-  ) {
-    final ratioSum = children.map((datum) => datum.startingRatio ?? 0).sum();
-
-    if (ratioSum > 1) {
-      throw ArgumentError.value(
-        ratioSum,
-        'startingRatio',
-        'The sum of all startingRatios must be less than or equal to 1.0',
-      );
-    }
-
-    final availableSpace = controller._availableSpace;
-
-    controller._children = children;
-    controller._availableSpace = -1;
-    controller._calculateChildSizes(availableSpace);
-  }
-}
 
 /// A controller to provide a programmatic interface to a [ResizableContainer].
 class ResizableController with ChangeNotifier {
@@ -35,6 +13,14 @@ class ResizableController with ChangeNotifier {
   double _nullRatioSpace = 0;
   List<double> _sizes = [];
   List<ResizableChild> _children = const [];
+
+  /// Configures this [ResizableController] with a list of children.
+  ///
+  /// This should only be used internally.
+  void setChildren(List<ResizableChild> children) {
+    _children = children;
+    _calculateChildSizes(_availableSpace);
+  }
 
   /// The sizes in pixels of each child.
   List<double> get sizes => _sizes;
@@ -46,13 +32,13 @@ class ResizableController with ChangeNotifier {
     }
 
     _calculateChildSizes(value);
-
     _availableSpace = value;
+
     notifyListeners();
   }
 
   void _calculateChildSizes(double availableSpace) {
-    if (_availableSpace == -1) {
+    if (availableSpace == -1) {
       _nullRatioSpace = _calculateSpaceForNullStartingRatios(availableSpace);
       _sizes = _calculateSizesBasedOnStartingRatios(availableSpace).toList();
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_resizable_container
 description: Add nestable, resizable containers to your Flutter app with ease.
-version: 1.0.0
+version: 2.0.0+beta.1
 homepage: https://github.com/andyhorn/flutter_resizable_container
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  decimal: ^2.3.3
   flutter:
     sdk: flutter
 
@@ -15,3 +16,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.1
+  mocktail: ^1.0.3

--- a/test/resizable_child_data_test.dart
+++ b/test/resizable_child_data_test.dart
@@ -1,47 +1,47 @@
-import 'package:flutter_resizable_container/flutter_resizable_container.dart';
+import 'package:flutter_resizable_container/src/resizable_child.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group(ResizableChildData, () {
+  group(ResizableChild, () {
     group('startingRatio', () {
       test('throws if less than 0', () {
         expect(
-          () => ResizableChildData(startingRatio: -0.1),
+          () => ResizableChild(startingRatio: -0.1),
           throwsAssertionError,
         );
       });
 
       test('throws if greater than 1', () {
         expect(
-          () => ResizableChildData(startingRatio: 1.1),
+          () => ResizableChild(startingRatio: 1.1),
           throwsAssertionError,
         );
       });
 
       test('allows null', () {
         expect(
-          () => const ResizableChildData(startingRatio: null),
+          () => const ResizableChild(startingRatio: null),
           isNot(throwsA(anything)),
         );
       });
 
       test('allows a value between 0 and 1', () {
         expect(
-          () => const ResizableChildData(startingRatio: 0.5),
+          () => const ResizableChild(startingRatio: 0.5),
           isNot(throwsA(anything)),
         );
       });
 
       test('allows 0', () {
         expect(
-          () => const ResizableChildData(startingRatio: 0),
+          () => const ResizableChild(startingRatio: 0),
           isNot(throwsA(anything)),
         );
       });
 
       test('allows 1', () {
         expect(
-          () => const ResizableChildData(startingRatio: 1),
+          () => const ResizableChild(startingRatio: 1),
           isNot(throwsA(anything)),
         );
       });

--- a/test/resizable_child_test.dart
+++ b/test/resizable_child_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/src/resizable_child.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -6,42 +7,42 @@ void main() {
     group('startingRatio', () {
       test('throws if less than 0', () {
         expect(
-          () => ResizableChild(startingRatio: -0.1),
+          () => ResizableChild(startingRatio: -0.1, child: const SizedBox()),
           throwsAssertionError,
         );
       });
 
       test('throws if greater than 1', () {
         expect(
-          () => ResizableChild(startingRatio: 1.1),
+          () => ResizableChild(startingRatio: 1.1, child: const SizedBox()),
           throwsAssertionError,
         );
       });
 
       test('allows null', () {
         expect(
-          () => const ResizableChild(startingRatio: null),
+          () => const ResizableChild(startingRatio: null, child: SizedBox()),
           isNot(throwsA(anything)),
         );
       });
 
       test('allows a value between 0 and 1', () {
         expect(
-          () => const ResizableChild(startingRatio: 0.5),
+          () => const ResizableChild(startingRatio: 0.5, child: SizedBox()),
           isNot(throwsA(anything)),
         );
       });
 
       test('allows 0', () {
         expect(
-          () => const ResizableChild(startingRatio: 0),
+          () => const ResizableChild(startingRatio: 0, child: SizedBox()),
           isNot(throwsA(anything)),
         );
       });
 
       test('allows 1', () {
         expect(
-          () => const ResizableChild(startingRatio: 1),
+          () => const ResizableChild(startingRatio: 1, child: SizedBox()),
           isNot(throwsA(anything)),
         );
       });

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -8,27 +8,26 @@ void main() {
     testWidgets(
       'throws an error if the child ratios are greater than 1',
       (tester) async {
+        final container = ResizableContainer(
+          controller: ResizableController(),
+          direction: Axis.horizontal,
+          children: const [
+            ResizableChild(
+              startingRatio: 0.5,
+              child: SizedBox.expand(),
+            ),
+            ResizableChild(
+              startingRatio: 0.6,
+              child: SizedBox.expand(),
+            ),
+          ],
+        );
+
         expect(
           () async => await tester.pumpWidget(
             MaterialApp(
               home: Scaffold(
-                body: ResizableContainer(
-                  controller: ResizableController(
-                    data: const [
-                      ResizableChild(
-                        startingRatio: 0.5,
-                      ),
-                      ResizableChild(
-                        startingRatio: 0.6,
-                      ),
-                    ],
-                  ),
-                  direction: Axis.horizontal,
-                  children: const [
-                    SizedBox.shrink(),
-                    SizedBox.shrink(),
-                  ],
-                ),
+                body: container,
               ),
             ),
           ),
@@ -37,49 +36,9 @@ void main() {
       },
     );
 
-    testWidgets(
-      'throws an error if the children and data are of different lengths',
-      (widgetTester) async {
-        final controller = ResizableController(
-          data: const [
-            ResizableChild(),
-            ResizableChild(),
-            ResizableChild(),
-          ],
-        );
-
-        expect(
-          () async => await widgetTester.pumpWidget(
-            MaterialApp(
-              home: Scaffold(
-                body: ResizableContainer(
-                  controller: controller,
-                  direction: Axis.horizontal,
-                  children: const [
-                    SizedBox.shrink(),
-                    SizedBox.shrink(),
-                  ],
-                ),
-              ),
-            ),
-          ),
-          throwsAssertionError,
-        );
-      },
-    );
-
     testWidgets('can resize by dragging divider', (tester) async {
       const dividerWidth = 2.0;
-      final controller = ResizableController(
-        data: const [
-          ResizableChild(
-            startingRatio: 0.5,
-          ),
-          ResizableChild(
-            startingRatio: 0.5,
-          ),
-        ],
-      );
+      final controller = ResizableController();
 
       await tester.binding.setSurfaceSize(const Size(1000, 1000));
 
@@ -93,11 +52,17 @@ void main() {
                 size: dividerWidth,
               ),
               children: const [
-                SizedBox.expand(
-                  key: Key('BoxA'),
+                ResizableChild(
+                  startingRatio: 0.5,
+                  child: SizedBox.expand(
+                    key: Key('BoxA'),
+                  ),
                 ),
-                SizedBox.expand(
-                  key: Key('BoxB'),
+                ResizableChild(
+                  startingRatio: 0.5,
+                  child: SizedBox.expand(
+                    key: Key('BoxB'),
+                  ),
                 ),
               ],
             ),
@@ -125,16 +90,7 @@ void main() {
 
     testWidgets('can resize using the controller', (tester) async {
       const dividerWidth = 2.0;
-      final controller = ResizableController(
-        data: const [
-          ResizableChild(
-            startingRatio: 0.5,
-          ),
-          ResizableChild(
-            startingRatio: 0.5,
-          ),
-        ],
-      );
+      final controller = ResizableController();
 
       await tester.binding.setSurfaceSize(const Size(1000, 1000));
 
@@ -148,11 +104,15 @@ void main() {
                 size: dividerWidth,
               ),
               children: const [
-                SizedBox.expand(
-                  key: Key('BoxA'),
+                ResizableChild(
+                  child: SizedBox.expand(
+                    key: Key('BoxA'),
+                  ),
                 ),
-                SizedBox.expand(
-                  key: Key('BoxB'),
+                ResizableChild(
+                  child: SizedBox.expand(
+                    key: Key('BoxB'),
+                  ),
                 ),
               ],
             ),
@@ -182,23 +142,16 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: ResizableContainer(
-              controller: ResizableController(
-                data: const [
-                  ResizableChild(
-                    startingRatio: 0.5,
-                    minSize: 200,
-                  ),
-                  ResizableChild(
-                    startingRatio: 0.5,
-                  ),
-                ],
-              ),
+              controller: ResizableController(),
               direction: Axis.horizontal,
               children: const [
-                SizedBox.expand(
-                  key: Key('BoxA'),
+                ResizableChild(
+                  minSize: 200,
+                  child: SizedBox.expand(
+                    key: Key('BoxA'),
+                  ),
                 ),
-                SizedBox.expand(),
+                ResizableChild(child: SizedBox.expand()),
               ],
             ),
           ),
@@ -222,27 +175,22 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: ResizableContainer(
-              controller: ResizableController(
-                data: const [
-                  ResizableChild(
-                    startingRatio: 0.5,
-                    maxSize: 700,
-                  ),
-                  ResizableChild(
-                    startingRatio: 0.5,
-                  ),
-                ],
-              ),
+              controller: ResizableController(),
               divider: const ResizableDivider(
                 size: dividerWidth,
               ),
               direction: Axis.horizontal,
               children: const [
-                SizedBox.expand(
-                  key: Key('BoxA'),
+                ResizableChild(
+                  maxSize: 700,
+                  child: SizedBox.expand(
+                    key: Key('BoxA'),
+                  ),
                 ),
-                SizedBox.expand(
-                  key: Key('BoxB'),
+                ResizableChild(
+                  child: SizedBox.expand(
+                    key: Key('BoxB'),
+                  ),
                 ),
               ],
             ),
@@ -270,27 +218,22 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: ResizableContainer(
-              controller: ResizableController(
-                data: const [
-                  ResizableChild(
-                    startingRatio: 0.5,
-                    minSize: 200,
-                  ),
-                  ResizableChild(
-                    startingRatio: 0.5,
-                  ),
-                ],
-              ),
+              controller: ResizableController(),
               divider: const ResizableDivider(
                 size: dividerWidth,
               ),
               direction: Axis.horizontal,
               children: const [
-                SizedBox.expand(
-                  key: Key('BoxA'),
+                ResizableChild(
+                  minSize: 200,
+                  child: SizedBox.expand(
+                    key: Key('BoxA'),
+                  ),
                 ),
-                SizedBox.expand(
-                  key: Key('BoxB'),
+                ResizableChild(
+                  child: SizedBox.expand(
+                    key: Key('BoxB'),
+                  ),
                 ),
               ],
             ),
@@ -318,15 +261,7 @@ void main() {
           const Size(1000, 1000),
         );
 
-        final controller = ResizableController(
-          data: const [
-            ResizableChild(
-              startingRatio: 0.5,
-            ),
-            ResizableChild(),
-            ResizableChild(),
-          ],
-        );
+        final controller = ResizableController();
 
         final container = ResizableContainer(
           controller: controller,
@@ -335,14 +270,21 @@ void main() {
             size: 2.0,
           ),
           children: const [
-            SizedBox.expand(
-              key: Key('Box A'),
+            ResizableChild(
+              startingRatio: 0.5,
+              child: SizedBox.expand(
+                key: Key('Box A'),
+              ),
             ),
-            SizedBox.expand(
-              key: Key('Box B'),
+            ResizableChild(
+              child: SizedBox.expand(
+                key: Key('Box B'),
+              ),
             ),
-            SizedBox.expand(
-              key: Key('Box C'),
+            ResizableChild(
+              child: SizedBox.expand(
+                key: Key('Box C'),
+              ),
             ),
           ],
         );

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -5,37 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group(ResizableContainer, () {
-    testWidgets(
-      'throws an error if the child ratios are greater than 1',
-      (tester) async {
-        final container = ResizableContainer(
-          controller: ResizableController(),
-          direction: Axis.horizontal,
-          children: const [
-            ResizableChild(
-              startingRatio: 0.5,
-              child: SizedBox.expand(),
-            ),
-            ResizableChild(
-              startingRatio: 0.6,
-              child: SizedBox.expand(),
-            ),
-          ],
-        );
-
-        expect(
-          () async => await tester.pumpWidget(
-            MaterialApp(
-              home: Scaffold(
-                body: container,
-              ),
-            ),
-          ),
-          throwsArgumentError,
-        );
-      },
-    );
-
     testWidgets('can resize by dragging divider', (tester) async {
       const dividerWidth = 2.0;
       final controller = ResizableController();

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -15,10 +15,10 @@ void main() {
                 body: ResizableContainer(
                   controller: ResizableController(
                     data: const [
-                      ResizableChildData(
+                      ResizableChild(
                         startingRatio: 0.5,
                       ),
-                      ResizableChildData(
+                      ResizableChild(
                         startingRatio: 0.6,
                       ),
                     ],
@@ -42,9 +42,9 @@ void main() {
       (widgetTester) async {
         final controller = ResizableController(
           data: const [
-            ResizableChildData(),
-            ResizableChildData(),
-            ResizableChildData(),
+            ResizableChild(),
+            ResizableChild(),
+            ResizableChild(),
           ],
         );
 
@@ -72,10 +72,10 @@ void main() {
       const dividerWidth = 2.0;
       final controller = ResizableController(
         data: const [
-          ResizableChildData(
+          ResizableChild(
             startingRatio: 0.5,
           ),
-          ResizableChildData(
+          ResizableChild(
             startingRatio: 0.5,
           ),
         ],
@@ -127,10 +127,10 @@ void main() {
       const dividerWidth = 2.0;
       final controller = ResizableController(
         data: const [
-          ResizableChildData(
+          ResizableChild(
             startingRatio: 0.5,
           ),
-          ResizableChildData(
+          ResizableChild(
             startingRatio: 0.5,
           ),
         ],
@@ -184,11 +184,11 @@ void main() {
             body: ResizableContainer(
               controller: ResizableController(
                 data: const [
-                  ResizableChildData(
+                  ResizableChild(
                     startingRatio: 0.5,
                     minSize: 200,
                   ),
-                  ResizableChildData(
+                  ResizableChild(
                     startingRatio: 0.5,
                   ),
                 ],
@@ -224,11 +224,11 @@ void main() {
             body: ResizableContainer(
               controller: ResizableController(
                 data: const [
-                  ResizableChildData(
+                  ResizableChild(
                     startingRatio: 0.5,
                     maxSize: 700,
                   ),
-                  ResizableChildData(
+                  ResizableChild(
                     startingRatio: 0.5,
                   ),
                 ],
@@ -272,11 +272,11 @@ void main() {
             body: ResizableContainer(
               controller: ResizableController(
                 data: const [
-                  ResizableChildData(
+                  ResizableChild(
                     startingRatio: 0.5,
                     minSize: 200,
                   ),
-                  ResizableChildData(
+                  ResizableChild(
                     startingRatio: 0.5,
                   ),
                 ],
@@ -320,11 +320,11 @@ void main() {
 
         final controller = ResizableController(
           data: const [
-            ResizableChildData(
+            ResizableChild(
               startingRatio: 0.5,
             ),
-            ResizableChildData(),
-            ResizableChildData(),
+            ResizableChild(),
+            ResizableChild(),
           ],
         );
 

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -281,5 +281,109 @@ void main() {
         expect(boxCSize, equals(const Size(249, 1000)));
       },
     );
+
+    testWidgets('children do not expand if set to false', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 1000));
+      await tester.pumpWidget(const _ToggleChildApp(expand: false));
+
+      expect(find.byKey(const Key('ChildA')), findsOneWidget);
+      expect(find.byKey(const Key('ChildB')), findsOneWidget);
+
+      expect(
+        tester.getSize(find.byKey(const Key('ChildA'))).width,
+        equals(499.0),
+      );
+      expect(
+        tester.getSize(find.byKey(const Key('ChildB'))).width,
+        equals(499.0),
+      );
+
+      await tester.tap(find.byKey(const Key('ToggleSwitch')));
+      await tester.pump();
+
+      expect(find.byKey(const Key('ChildA')), findsOneWidget);
+      expect(find.byKey(const Key('ChildB')), findsNothing);
+      expect(
+        tester.getSize(find.byKey(const Key('ChildA'))).width,
+        equals(500),
+      );
+    });
+
+    testWidgets('children auto-expand if set to true', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 1000));
+      await tester.pumpWidget(const _ToggleChildApp(expand: true));
+
+      expect(find.byKey(const Key('ChildA')), findsOneWidget);
+      expect(find.byKey(const Key('ChildB')), findsOneWidget);
+
+      expect(
+        tester.getSize(find.byKey(const Key('ChildA'))).width,
+        equals(499.0),
+      );
+      expect(
+        tester.getSize(find.byKey(const Key('ChildB'))).width,
+        equals(499.0),
+      );
+
+      await tester.tap(find.byKey(const Key('ToggleSwitch')));
+      await tester.pump();
+
+      expect(find.byKey(const Key('ChildA')), findsOneWidget);
+      expect(find.byKey(const Key('ChildB')), findsNothing);
+      expect(
+        tester.getSize(find.byKey(const Key('ChildA'))).width,
+        equals(1000),
+      );
+    });
   });
+}
+
+class _ToggleChildApp extends StatefulWidget {
+  const _ToggleChildApp({required this.expand});
+
+  final bool expand;
+
+  @override
+  State<_ToggleChildApp> createState() => __ToggleChildAppState();
+}
+
+class __ToggleChildAppState extends State<_ToggleChildApp> {
+  bool hidden = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          actions: [
+            Switch(
+              key: const Key('ToggleSwitch'),
+              value: hidden,
+              onChanged: (_) => setState(() => hidden = !hidden),
+            ),
+          ],
+        ),
+        body: ResizableContainer(
+          controller: ResizableController(),
+          direction: Axis.horizontal,
+          children: [
+            ResizableChild(
+              startingRatio: 0.5,
+              expand: widget.expand,
+              child: const SizedBox.expand(
+                key: Key('ChildA'),
+              ),
+            ),
+            if (!hidden)
+              const ResizableChild(
+                startingRatio: 0.5,
+                child: SizedBox.expand(
+                  key: Key('ChildB'),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
+import 'package:flutter_resizable_container/src/resizable_controller.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -6,22 +8,30 @@ void main() {
     late ResizableController controller;
 
     setUp(() {
-      controller = ResizableController(
-        data: const [
+      controller = ResizableController();
+
+      ResizableControllerManager.setChildren(
+        controller,
+        const [
           ResizableChild(
             startingRatio: 0.1,
+            child: SizedBox(),
           ),
           ResizableChild(
             startingRatio: 0.1,
+            child: SizedBox(),
           ),
           ResizableChild(
             startingRatio: 0.25,
+            child: SizedBox(),
           ),
           ResizableChild(
             startingRatio: 0.25,
+            child: SizedBox(),
           ),
           ResizableChild(
             startingRatio: 0.3,
+            child: SizedBox(),
           ),
         ],
       );

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -8,19 +8,19 @@ void main() {
     setUp(() {
       controller = ResizableController(
         data: const [
-          ResizableChildData(
+          ResizableChild(
             startingRatio: 0.1,
           ),
-          ResizableChildData(
+          ResizableChild(
             startingRatio: 0.1,
           ),
-          ResizableChildData(
+          ResizableChild(
             startingRatio: 0.25,
           ),
-          ResizableChildData(
+          ResizableChild(
             startingRatio: 0.25,
           ),
-          ResizableChildData(
+          ResizableChild(
             startingRatio: 0.3,
           ),
         ],

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
-import 'package:flutter_resizable_container/src/resizable_controller.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -9,39 +8,38 @@ void main() {
 
     setUp(() {
       controller = ResizableController();
-
-      ResizableControllerManager.setChildren(
-        controller,
-        const [
-          ResizableChild(
-            startingRatio: 0.1,
-            child: SizedBox(),
-          ),
-          ResizableChild(
-            startingRatio: 0.1,
-            child: SizedBox(),
-          ),
-          ResizableChild(
-            startingRatio: 0.25,
-            child: SizedBox(),
-          ),
-          ResizableChild(
-            startingRatio: 0.25,
-            child: SizedBox(),
-          ),
-          ResizableChild(
-            startingRatio: 0.3,
-            child: SizedBox(),
-          ),
-        ],
-      );
     });
 
     tearDown(() => controller.dispose());
 
     group('ratios', () {
       setUp(() {
-        controller.availableSpace = 1000.0;
+        controller.setChildren(
+          const [
+            ResizableChild(
+              startingRatio: 0.1,
+              child: SizedBox(),
+            ),
+            ResizableChild(
+              startingRatio: 0.1,
+              child: SizedBox(),
+            ),
+            ResizableChild(
+              startingRatio: 0.25,
+              child: SizedBox(),
+            ),
+            ResizableChild(
+              startingRatio: 0.25,
+              child: SizedBox(),
+            ),
+            ResizableChild(
+              startingRatio: 0.3,
+              child: SizedBox(),
+            ),
+          ],
+        );
+
+        controller.availableSpace = 1000;
       });
 
       test('returns the ratios of all the children', () {

--- a/test/resizable_divider_test.dart
+++ b/test/resizable_divider_test.dart
@@ -51,19 +51,18 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: ResizableContainer(
-                controller: ResizableController(
-                  data: const [
-                    ResizableChild(),
-                    ResizableChild(),
-                  ],
-                ),
+                controller: ResizableController(),
                 direction: Axis.horizontal,
                 divider: ResizableDivider(
                   onHoverEnter: () => hovered = true,
                 ),
                 children: const [
-                  SizedBox.expand(),
-                  SizedBox.expand(),
+                  ResizableChild(
+                    child: SizedBox.expand(),
+                  ),
+                  ResizableChild(
+                    child: SizedBox.expand(),
+                  ),
                 ],
               ),
             ),
@@ -97,19 +96,18 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: ResizableContainer(
-                controller: ResizableController(
-                  data: const [
-                    ResizableChild(),
-                    ResizableChild(),
-                  ],
-                ),
+                controller: ResizableController(),
                 direction: Axis.horizontal,
                 divider: ResizableDivider(
                   onHoverExit: () => hovered = false,
                 ),
                 children: const [
-                  SizedBox.expand(),
-                  SizedBox.expand(),
+                  ResizableChild(
+                    child: SizedBox.expand(),
+                  ),
+                  ResizableChild(
+                    child: SizedBox.expand(),
+                  ),
                 ],
               ),
             ),

--- a/test/resizable_divider_test.dart
+++ b/test/resizable_divider_test.dart
@@ -53,8 +53,8 @@ void main() {
               body: ResizableContainer(
                 controller: ResizableController(
                   data: const [
-                    ResizableChildData(),
-                    ResizableChildData(),
+                    ResizableChild(),
+                    ResizableChild(),
                   ],
                 ),
                 direction: Axis.horizontal,
@@ -99,8 +99,8 @@ void main() {
               body: ResizableContainer(
                 controller: ResizableController(
                   data: const [
-                    ResizableChildData(),
-                    ResizableChildData(),
+                    ResizableChild(),
+                    ResizableChild(),
                   ],
                 ),
                 direction: Axis.horizontal,


### PR DESCRIPTION
This PR moves the `ResizableChild` configuration classes _back_ into the `ResizableContainer`'s constructor so that they can be modified on-the-fly without needing to re-create or manually update the `ResizableController`.

This PR also adds an `expand` flag to the `ResizableChild` to control whether or not it will automatically fill-in any remaining available space if it has a `startingRatio` constraint.