### PR TITLE
fix: Fix versioning syntax

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -186,7 +186,7 @@ class _ExampleAppState extends State<ExampleApp> {
                         vertical: 1,
                         horizontal: 8,
                       ),
-                      child: Text('v${data.version} (${data.buildNumber})'),
+                      child: Text('v${data.version}'),
                     );
                   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0+beta.1"
+    version: "2.0.0-beta.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.0.0+beta.1
+version: 2.0.0-beta.1
 
 environment:
   sdk: ">=2.18.6 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_resizable_container
 description: Add nestable, resizable containers to your Flutter app with ease.
-version: 2.0.0+beta.1
+version: 2.0.0-beta.1
 homepage: https://github.com/andyhorn/flutter_resizable_container
 
 environment:


### PR DESCRIPTION
This PR fixes the version syntax in the `pubspec.yaml` file to properly tag it as a pre-release/preview version.