### PR TITLE
feat: Add expand/flex sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0-beta.3
+
+- Add a `ResizableSize.expand` constructor that takes a `flex` integer (defaults to 1)
+- Remove the optionality of the `size` parameter in `ResizableChild` and use a default `ResizableSize.expand()` value
+- Adjust the controller to disallow `null` values for `ResizableSize` arguments
+- Adjust the controller to prioritize modifying `ResizableSize.expand` children when scaling the window (up or down) over the `pixel` and `ratio` children, unless no `expand` children are set
+
 ## 2.0.0-beta.2
 
 - Added a new `ResizableSize` class that defines a "size" in pixels or as a ratio

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,10 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
-const ratio1 = 0.75;
-const ratio2 = 0.25;
-const ratio3 = 0.5;
-const ratio4 = 0.5;
+const rightPanelRatio = 0.25;
 
 void main() {
   runApp(const ExampleApp());
@@ -33,14 +30,22 @@ class _ExampleAppState extends State<ExampleApp> {
 
     controller1.addListener(() {
       final sizes = controller1.sizes.map((size) => size.toStringAsFixed(2));
+      final ratios = controller1.ratios.map(
+        (ratio) => ratio.toStringAsFixed(2),
+      );
 
       debugPrint('Controller 1 sizes: ${sizes.join(', ')}');
+      debugPrint('Controller 1 ratios: ${ratios.join(', ')}');
     });
 
     controller2.addListener(() {
       final sizes = controller2.sizes.map((size) => size.toStringAsFixed(2));
+      final ratios = controller2.ratios.map(
+        (ratio) => ratio.toStringAsFixed(2),
+      );
 
       debugPrint('Controller 2 sizes: ${sizes.join(', ')}');
+      debugPrint('Controller 2 ratios: ${ratios.join(', ')}');
     });
   }
 
@@ -54,6 +59,7 @@ class _ExampleAppState extends State<ExampleApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      title: 'ResizableContainer',
       debugShowCheckedModeBanner: false,
       theme: ThemeData.light(useMaterial3: true),
       home: Scaffold(
@@ -63,22 +69,18 @@ class _ExampleAppState extends State<ExampleApp> {
             ElevatedButton(
               onPressed: () {
                 controller1.setSizes(const [
-                  ResizableSize.ratio(ratio1),
-                  ResizableSize.ratio(ratio2),
+                  ResizableSize.expand(),
+                  ResizableSize.ratio(rightPanelRatio),
                 ]);
 
-                if (!hidden) {
-                  controller2.setSizes(const [
-                    ResizableSize.ratio(ratio3),
-                    ResizableSize.ratio(ratio4),
-                  ]);
-                } else {
-                  controller2.setSizes([
+                controller2.setSizes([
+                  const ResizableSize.expand(),
+                  if (!hidden) ...[
                     const ResizableSize.expand(),
-                  ]);
-                }
+                  ],
+                ]);
               },
-              child: const Text("Reset ratios"),
+              child: const Text("Reset sizes"),
             ),
             const SizedBox(width: 10),
             ElevatedButton(
@@ -97,12 +99,6 @@ class _ExampleAppState extends State<ExampleApp> {
             ElevatedButton(
               onPressed: () => setState(() => hidden = !hidden),
               child: Text(hidden ? 'Show Child B' : 'Hide Child B'),
-            ),
-            const SizedBox(width: 10),
-            const Text('Auto-expand?'),
-            Switch(
-              value: expand,
-              onChanged: (_) => setState(() => expand = !expand),
             ),
             const SizedBox(width: 10),
           ],
@@ -135,13 +131,13 @@ class _ExampleAppState extends State<ExampleApp> {
                             constraints: constraints,
                             label: direction == Axis.horizontal
                                 ? 'Left Pane'
-                                : 'Right Pane',
+                                : 'Top Pane',
                           );
                         },
                       ),
                     ),
                     ResizableChild(
-                      size: const ResizableSize.ratio(ratio2),
+                      size: const ResizableSize.ratio(rightPanelRatio),
                       maxSize: 500,
                       child: ResizableContainer(
                         controller: controller2,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -73,7 +73,9 @@ class _ExampleAppState extends State<ExampleApp> {
                     ResizableSize.ratio(ratio4),
                   ]);
                 } else {
-                  controller2.setSizes([null]);
+                  controller2.setSizes([
+                    const ResizableSize.expand(),
+                  ]);
                 }
               },
               child: const Text("Reset ratios"),
@@ -124,7 +126,7 @@ class _ExampleAppState extends State<ExampleApp> {
                   ),
                   children: [
                     ResizableChild(
-                      startingSize: const ResizableSize.ratio(ratio1),
+                      size: const ResizableSize.expand(),
                       minSize: 150,
                       child: LayoutBuilder(
                         builder: (context, constraints) {
@@ -139,7 +141,7 @@ class _ExampleAppState extends State<ExampleApp> {
                       ),
                     ),
                     ResizableChild(
-                      startingSize: const ResizableSize.ratio(ratio2),
+                      size: const ResizableSize.ratio(ratio2),
                       maxSize: 500,
                       child: ResizableContainer(
                         controller: controller2,
@@ -151,8 +153,7 @@ class _ExampleAppState extends State<ExampleApp> {
                             : Axis.horizontal,
                         children: [
                           ResizableChild(
-                            expand: expand,
-                            startingSize: const ResizableSize.ratio(ratio3),
+                            size: const ResizableSize.expand(),
                             child: LayoutBuilder(
                               builder: (context, constraints) {
                                 return ExpandedChild(
@@ -165,7 +166,7 @@ class _ExampleAppState extends State<ExampleApp> {
                           ),
                           if (!hidden) ...[
                             ResizableChild(
-                              startingSize: const ResizableSize.ratio(ratio4),
+                              size: const ResizableSize.expand(),
                               child: LayoutBuilder(
                                 builder: (context, constraints) {
                                   return ExpandedChild(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -74,7 +76,7 @@ class _ExampleAppState extends State<ExampleApp> {
                 ]);
 
                 controller2.setSizes([
-                  const ResizableSize.expand(),
+                  const ResizableSize.expand(flex: 2),
                   if (!hidden) ...[
                     const ResizableSize.expand(),
                   ],
@@ -126,12 +128,64 @@ class _ExampleAppState extends State<ExampleApp> {
                       minSize: 150,
                       child: LayoutBuilder(
                         builder: (context, constraints) {
-                          return ExpandedChild(
-                            color: Colors.green,
-                            constraints: constraints,
-                            label: direction == Axis.horizontal
-                                ? 'Left Pane'
-                                : 'Top Pane',
+                          final pane = switch (direction) {
+                            Axis.horizontal => 'Left Pane',
+                            Axis.vertical => 'Top Pane',
+                          };
+
+                          return DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .primaryContainer,
+                            ),
+                            child: SizedBox.expand(
+                              child: Stack(
+                                children: [
+                                  Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.stretch,
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Text(
+                                        pane,
+                                        textAlign: TextAlign.center,
+                                      ),
+                                      ConstraintsLabel(
+                                        constraints: constraints,
+                                      ),
+                                    ],
+                                  ),
+                                  if (direction == Axis.horizontal) ...[
+                                    const Align(
+                                      alignment: Alignment.topCenter,
+                                      child: Text(
+                                        'expand()',
+                                        textAlign: TextAlign.center,
+                                      ),
+                                    ),
+                                  ] else ...[
+                                    Align(
+                                      alignment: Alignment.centerLeft,
+                                      child: Transform.translate(
+                                        offset: const Offset(-35, -35),
+                                        child: Transform.rotate(
+                                          angle: -pi / 2,
+                                          alignment: Alignment.centerRight,
+                                          child: Text(
+                                            'expand()',
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .labelLarge,
+                                            textAlign: TextAlign.center,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ],
+                              ),
+                            ),
                           );
                         },
                       ),
@@ -144,18 +198,100 @@ class _ExampleAppState extends State<ExampleApp> {
                         divider: const ResizableDivider(
                           color: Colors.green,
                         ),
-                        direction: direction == Axis.horizontal
-                            ? Axis.vertical
-                            : Axis.horizontal,
+                        direction: switch (direction) {
+                          Axis.vertical => Axis.horizontal,
+                          Axis.horizontal => Axis.vertical,
+                        },
                         children: [
                           ResizableChild(
-                            size: const ResizableSize.expand(),
+                            size: const ResizableSize.expand(flex: 2),
                             child: LayoutBuilder(
                               builder: (context, constraints) {
-                                return ExpandedChild(
-                                  color: Colors.pink,
-                                  constraints: constraints,
-                                  label: 'Nested Child A',
+                                final pane = switch (direction) {
+                                  Axis.horizontal => 'Top Right',
+                                  Axis.vertical => 'Bottom Left',
+                                };
+
+                                return DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .secondaryContainer,
+                                  ),
+                                  child: SizedBox.expand(
+                                    child: Stack(
+                                      children: [
+                                        if (direction == Axis.horizontal) ...[
+                                          const Align(
+                                            alignment: Alignment.topCenter,
+                                            child: Text(
+                                              'ratio(0.25)',
+                                              textAlign: TextAlign.center,
+                                            ),
+                                          ),
+                                        ] else ...[
+                                          Align(
+                                            alignment: Alignment.centerLeft,
+                                            child: Transform.translate(
+                                              offset: const Offset(-50, -35),
+                                              child: Transform.rotate(
+                                                angle: -pi / 2,
+                                                alignment:
+                                                    Alignment.centerRight,
+                                                child: Text(
+                                                  'ratio(0.25)',
+                                                  style: Theme.of(context)
+                                                      .textTheme
+                                                      .labelLarge,
+                                                  textAlign: TextAlign.center,
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                        Column(
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.center,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.stretch,
+                                          children: [
+                                            Text(
+                                              pane,
+                                              textAlign: TextAlign.center,
+                                            ),
+                                            ConstraintsLabel(
+                                              constraints: constraints,
+                                            ),
+                                          ],
+                                        ),
+                                        if (direction == Axis.horizontal) ...[
+                                          Align(
+                                            alignment: Alignment.centerRight,
+                                            child: Transform.translate(
+                                              offset: const Offset(-10, 50),
+                                              child: Transform.rotate(
+                                                angle: pi / 2,
+                                                alignment:
+                                                    Alignment.centerRight,
+                                                child: Text(
+                                                  'expand(flex: 2)',
+                                                  style: Theme.of(context)
+                                                      .textTheme
+                                                      .labelLarge,
+                                                  textAlign: TextAlign.center,
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                        ] else ...[
+                                          const Align(
+                                            alignment: Alignment.topCenter,
+                                            child: Text('expand(flex: 2)'),
+                                          ),
+                                        ],
+                                      ],
+                                    ),
+                                  ),
                                 );
                               },
                             ),
@@ -165,10 +301,55 @@ class _ExampleAppState extends State<ExampleApp> {
                               size: const ResizableSize.expand(),
                               child: LayoutBuilder(
                                 builder: (context, constraints) {
-                                  return ExpandedChild(
-                                    label: 'Nested Child B',
-                                    color: Colors.amber,
-                                    constraints: constraints,
+                                  return DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .tertiaryContainer,
+                                    ),
+                                    child: SizedBox.expand(
+                                      child: Stack(
+                                        children: [
+                                          Center(
+                                            child: Column(
+                                              mainAxisAlignment:
+                                                  MainAxisAlignment.center,
+                                              children: [
+                                                const Text('Bottom Right'),
+                                                ConstraintsLabel(
+                                                  constraints: constraints,
+                                                ),
+                                              ],
+                                            ),
+                                          ),
+                                          if (direction == Axis.horizontal) ...[
+                                            Align(
+                                              alignment: Alignment.centerRight,
+                                              child: Transform.translate(
+                                                offset: const Offset(-10, 30),
+                                                child: Transform.rotate(
+                                                  angle: pi / 2,
+                                                  alignment:
+                                                      Alignment.centerRight,
+                                                  child: Text(
+                                                    'expand()',
+                                                    style: Theme.of(context)
+                                                        .textTheme
+                                                        .labelLarge,
+                                                    textAlign: TextAlign.center,
+                                                  ),
+                                                ),
+                                              ),
+                                            ),
+                                          ] else ...[
+                                            const Align(
+                                              alignment: Alignment.topCenter,
+                                              child: Text('expand()'),
+                                            ),
+                                          ],
+                                        ],
+                                      ),
+                                    ),
                                   );
                                 },
                               ),
@@ -205,6 +386,23 @@ class _ExampleAppState extends State<ExampleApp> {
   }
 }
 
+class ConstraintsLabel extends StatelessWidget {
+  const ConstraintsLabel({super.key, required this.constraints});
+
+  final BoxConstraints constraints;
+
+  @override
+  Widget build(BuildContext context) {
+    final height = constraints.maxHeight.toStringAsFixed(2);
+    final width = constraints.maxWidth.toStringAsFixed(2);
+
+    return Text(
+      'Height: $height px\nWidth: $width px',
+      textAlign: TextAlign.center,
+    );
+  }
+}
+
 class ExpandedChild extends StatelessWidget {
   const ExpandedChild({
     super.key,
@@ -219,19 +417,18 @@ class ExpandedChild extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final height = constraints.maxHeight.toStringAsFixed(2);
-    final width = constraints.maxWidth.toStringAsFixed(2);
-
     return DecoratedBox(
       decoration: BoxDecoration(
         color: color,
       ),
       child: SizedBox.expand(
-        child: Center(
-          child: Text(
-            '$label ($height x $width)',
-            textAlign: TextAlign.center,
-          ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(label, textAlign: TextAlign.center),
+            ConstraintsLabel(constraints: constraints),
+          ],
         ),
       ),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-beta.2"
+    version: "2.0.0-beta.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.0.0-beta.1
+version: 2.0.0-beta.3
 
 environment:
   sdk: ">=2.18.6 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 2.0.0-beta.3
 
 environment:
-  sdk: ">=2.18.6 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/lib/src/extensions/iterable_ext.dart
+++ b/lib/src/extensions/iterable_ext.dart
@@ -1,7 +1,21 @@
+import 'package:flutter_resizable_container/flutter_resizable_container.dart';
+
 extension IterableNumExtensions on Iterable<num> {
   num sum() => fold(0, (sum, current) => sum + current);
 }
 
-extension IterableExtensions on Iterable {
+extension IterableExtensions<T> on Iterable<T> {
   int nullCount() => where((item) => item == null).length;
+  int count(bool Function(T) test) => where(test).length;
+  num sum(num Function(T) extractor) =>
+      fold(0.0, (sum, current) => sum + extractor(current));
+}
+
+extension ResizableSizeIterableExtensions on Iterable<ResizableSize> {
+  double get totalPixels =>
+      where((size) => size.isPixels).sum((size) => size.value).toDouble();
+  double get totalRatio =>
+      where((size) => size.isRatio).sum((size) => size.value).toDouble();
+  int get flexCount =>
+      where((size) => size.isExpand).sum((size) => size.value).toInt();
 }

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -6,15 +6,10 @@ class ResizableChild {
   /// Create a new instance of the [ResizableChild] class.
   const ResizableChild({
     required this.child,
-    this.expand = false,
+    required this.size,
     this.maxSize,
     this.minSize,
-    this.startingSize,
   });
-
-  /// Whether this child should expand to fill empty space, even if it extends
-  /// beyond its [startingSize].
-  final bool expand;
 
   /// The (optional) maximum size (in px) of this child Widget.
   final double? maxSize;
@@ -22,42 +17,43 @@ class ResizableChild {
   /// The (optional) minimum size (in px) of this child Widget.
   final double? minSize;
 
-  /// The starting size of the corresponding widget. May use a ratio of the
-  /// available space or an absolute size in logical pixels.
+  /// The size of the corresponding widget. May use a ratio of the
+  /// available space, an absolute size in logical pixels, or it can
+  /// auto-expand to fill available space.
   ///
   /// ```dart
   /// // Ratio of available space
-  /// startingSize: const ResizableStartingSize.ratio(0.25);
+  /// size: const ResizableSize.ratio(0.25);
   ///
   /// // Absolute size in logical pixels
-  /// startingSize: const ResizableStartingSize.pixels(300);
+  /// size: const ResizableSize.pixels(300);
+  ///
+  /// // Auto-fill available space
+  /// size: const ResizableSize.expand(),
   /// ```
-  final ResizableSize? startingSize;
+  final ResizableSize size;
 
   /// The child [Widget]
   final Widget child;
 
   @override
   String toString() => 'ResizableChildData('
-      'startingSize: $startingSize, '
+      'size: $size, '
       'maxSize: $maxSize, '
       'minSize: $minSize, '
-      'child: $child, '
-      'expand: $expand)';
+      'child: $child)';
 
   @override
   operator ==(Object other) =>
       other is ResizableChild &&
-      other.expand == expand &&
-      other.startingSize == startingSize &&
+      other.size == size &&
       other.maxSize == maxSize &&
       other.minSize == minSize &&
       other.child.runtimeType == child.runtimeType;
 
   @override
   int get hashCode => Object.hash(
-        expand,
-        startingSize,
+        size,
         maxSize,
         minSize,
         child,

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -6,7 +6,7 @@ class ResizableChild {
   /// Create a new instance of the [ResizableChild] class.
   const ResizableChild({
     required this.child,
-    required this.size,
+    this.size = const ResizableSize.expand(),
     this.maxSize,
     this.minSize,
   });

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 import 'package:flutter_resizable_container/src/extensions/box_constraints_ext.dart';
 import 'package:flutter_resizable_container/src/resizable_container_divider.dart';
+import 'package:flutter_resizable_container/src/resizable_controller.dart';
 
 /// A container that holds multiple child [Widget]s that can be resized.
 ///
@@ -41,12 +42,13 @@ class ResizableContainer extends StatefulWidget {
 class _ResizableContainerState extends State<ResizableContainer> {
   late final controller = widget.controller ?? ResizableController();
   late final isDefaultController = widget.controller == null;
+  late final manager = ResizableControllerManager(controller);
 
   @override
   void initState() {
     super.initState();
 
-    controller.setChildren(widget.children);
+    manager.setChildren(widget.children);
   }
 
   @override
@@ -54,7 +56,7 @@ class _ResizableContainerState extends State<ResizableContainer> {
     final hasChanges = !listEquals(oldWidget.children, widget.children);
 
     if (hasChanges) {
-      controller.updateChildren(widget.children);
+      manager.updateChildren(widget.children);
     }
 
     super.didUpdateWidget(oldWidget);
@@ -74,7 +76,7 @@ class _ResizableContainerState extends State<ResizableContainer> {
     return LayoutBuilder(
       builder: (context, constraints) {
         final availableSpace = _getAvailableSpace(constraints);
-        controller.setAvailableSpace(availableSpace);
+        manager.setAvailableSpace(availableSpace);
 
         return AnimatedBuilder(
           animation: controller,
@@ -110,7 +112,7 @@ class _ResizableContainerState extends State<ResizableContainer> {
                     ResizableContainerDivider(
                       config: widget.divider,
                       direction: widget.direction,
-                      onResizeUpdate: (delta) => controller.adjustChildSize(
+                      onResizeUpdate: (delta) => manager.adjustChildSize(
                         index: i,
                         delta: delta,
                       ),

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -168,7 +168,7 @@ class ResizableController with ChangeNotifier {
 
       for (var i = 0; i < _children.length; i++) {
         if (_children[i].size.isExpand) {
-          _sizes[i] += deltaPerExpandable;
+          _sizes[i] += deltaPerExpandable * _children[i].size.value;
         }
       }
     } else {

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -151,7 +151,7 @@ class ResizableController with ChangeNotifier {
       (size) => switch (size.type) {
         SizeType.pixels => size.value,
         SizeType.ratio => remainingSpace * size.value,
-        SizeType.expand => flexUnitSpace * size.value.truncate(),
+        SizeType.expand => flexUnitSpace * size.value,
       },
     );
 
@@ -162,21 +162,36 @@ class ResizableController with ChangeNotifier {
     final flexCount = _children.map((child) => child.size).flexCount;
 
     if (flexCount > 0) {
-      // If children are set to expand, adjust them instead of the others
-      final delta = availableSpace - _availableSpace;
-      final deltaPerExpandable = delta / flexCount;
-
-      for (var i = 0; i < _children.length; i++) {
-        if (_children[i].size.isExpand) {
-          _sizes[i] += deltaPerExpandable * _children[i].size.value;
-        }
-      }
+      // If any children are set to expand, adjust them instead of any
+      // statically-sized children
+      _flexExpandableChildren(
+        availableSpace: availableSpace,
+        flexCount: flexCount,
+      );
     } else {
       // If no children are set to expand, then scale each child uniformly
-      for (var i = 0; i < _children.length; i++) {
-        final currentRatio = _sizes[i] / _availableSpace;
-        _sizes[i] = currentRatio * availableSpace;
+      _adjustChildrenUniformly(availableSpace);
+    }
+  }
+
+  void _flexExpandableChildren({
+    required double availableSpace,
+    required int flexCount,
+  }) {
+    final delta = availableSpace - _availableSpace;
+    final deltaPerExpandable = delta / flexCount;
+
+    for (var i = 0; i < _children.length; i++) {
+      if (_children[i].size.isExpand) {
+        _sizes[i] += deltaPerExpandable * _children[i].size.value;
       }
+    }
+  }
+
+  void _adjustChildrenUniformly(double availableSpace) {
+    for (var i = 0; i < _children.length; i++) {
+      final currentRatio = _sizes[i] / _availableSpace;
+      _sizes[i] = currentRatio * availableSpace;
     }
   }
 

--- a/lib/src/resizable_size.dart
+++ b/lib/src/resizable_size.dart
@@ -1,42 +1,45 @@
 enum SizeType {
   ratio,
   pixels,
+  expand,
 }
 
 final class ResizableSize {
   const ResizableSize.pixels(double pixels)
       // ignore: prefer_initializing_formals
-      : pixels = pixels,
-        ratio = null,
+      : _value = pixels,
         type = SizeType.pixels,
         assert(pixels >= 0, 'Value cannot be less than 0.');
 
   const ResizableSize.ratio(double ratio)
       // ignore: prefer_initializing_formals
-      : ratio = ratio,
-        pixels = null,
+      : _value = ratio,
         type = SizeType.ratio,
         assert(
           ratio >= 0 && ratio <= 1,
           'Value must be between 0 and 1, inclusive.',
         );
 
-  final double? ratio;
-  final double? pixels;
+  const ResizableSize.expand({int flex = 1})
+      : _value = flex,
+        type = SizeType.expand,
+        assert(flex > 0, 'Flex value must be greater than 0.');
+
+  final num _value;
   final SizeType type;
 
-  double get value => switch (type) {
-        SizeType.ratio => ratio!,
-        SizeType.pixels => pixels!,
-      };
+  double get value => _value.toDouble();
+  bool get isRatio => type == SizeType.ratio;
+  bool get isPixels => type == SizeType.pixels;
+  bool get isExpand => type == SizeType.expand;
 
   @override
-  String toString() => 'ResizableSize(type: $type, value: $value)';
+  String toString() => 'ResizableSize(type: $type, value: $_value)';
 
   @override
   operator ==(Object other) =>
-      other is ResizableSize && other.type == type && other.value == value;
+      other is ResizableSize && other.type == type && other._value == _value;
 
   @override
-  int get hashCode => Object.hash(type, value);
+  int get hashCode => Object.hash(type, _value);
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,8 +1,0 @@
-/// Returns the sum of a list.
-num sum(List<num> list) {
-  num result = 0;
-  for (final element in list) {
-    result += element;
-  }
-  return result;
-}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_resizable_container
 description: Add nestable, resizable containers to your Flutter app with ease.
-version: 2.0.0-beta.2
+version: 2.0.0-beta.3
 homepage: https://github.com/andyhorn/flutter_resizable_container
 
 environment:

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -22,13 +22,13 @@ void main() {
               ),
               children: const [
                 ResizableChild(
-                  startingSize: ResizableSize.ratio(0.5),
+                  size: ResizableSize.ratio(0.5),
                   child: SizedBox.expand(
                     key: Key('BoxA'),
                   ),
                 ),
                 ResizableChild(
-                  startingSize: ResizableSize.ratio(0.5),
+                  size: ResizableSize.ratio(0.5),
                   child: SizedBox.expand(
                     key: Key('BoxB'),
                   ),
@@ -223,101 +223,20 @@ void main() {
       expect(boxBSize, const Size(800 - dividerWidth, 1000));
     });
 
-    testWidgets(
-      'null starting ratios are allotted space evenly',
-      (widgetTester) async {
-        await widgetTester.binding.setSurfaceSize(
-          const Size(1000, 1000),
-        );
-
-        await widgetTester.pumpWidget(
-          const MaterialApp(
-            home: Scaffold(
-              body: ResizableContainer(
-                direction: Axis.horizontal,
-                divider: ResizableDivider(
-                  size: 2.0,
-                ),
-                children: [
-                  ResizableChild(
-                    startingSize: ResizableSize.ratio(0.5),
-                    child: SizedBox.expand(
-                      key: Key('Box A'),
-                    ),
-                  ),
-                  ResizableChild(
-                    child: SizedBox.expand(
-                      key: Key('Box B'),
-                    ),
-                  ),
-                  ResizableChild(
-                    child: SizedBox.expand(
-                      key: Key('Box C'),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        );
-
-        final boxAFinder = find.byKey(const Key('Box A'));
-        final boxBFinder = find.byKey(const Key('Box B'));
-        final boxCFinder = find.byKey(const Key('Box C'));
-
-        final boxASize = widgetTester.getSize(boxAFinder);
-        final boxBSize = widgetTester.getSize(boxBFinder);
-        final boxCSize = widgetTester.getSize(boxCFinder);
-
-        // slightly less than 500, 250, and 250 because of the space
-        // used by the dividers.
-        expect(boxASize, equals(const Size(498, 1000)));
-        expect(boxBSize, equals(const Size(249, 1000)));
-        expect(boxCSize, equals(const Size(249, 1000)));
-      },
-    );
-
-    testWidgets('children do not expand if set to false', (tester) async {
+    testWidgets('children expand appropriately', (tester) async {
       await tester.binding.setSurfaceSize(const Size(1000, 1000));
-      await tester.pumpWidget(const _ToggleChildApp(expand: false));
+      await tester.pumpWidget(const _ToggleChildApp());
 
       expect(find.byKey(const Key('ChildA')), findsOneWidget);
       expect(find.byKey(const Key('ChildB')), findsOneWidget);
 
       expect(
         tester.getSize(find.byKey(const Key('ChildA'))).width,
-        equals(499.0),
+        equals((1000 - 2) * 2 / 3),
       );
       expect(
         tester.getSize(find.byKey(const Key('ChildB'))).width,
-        equals(499.0),
-      );
-
-      await tester.tap(find.byKey(const Key('ToggleSwitch')));
-      await tester.pump();
-
-      expect(find.byKey(const Key('ChildA')), findsOneWidget);
-      expect(find.byKey(const Key('ChildB')), findsNothing);
-      expect(
-        tester.getSize(find.byKey(const Key('ChildA'))).width,
-        equals(500),
-      );
-    });
-
-    testWidgets('children auto-expand if set to true', (tester) async {
-      await tester.binding.setSurfaceSize(const Size(1000, 1000));
-      await tester.pumpWidget(const _ToggleChildApp(expand: true));
-
-      expect(find.byKey(const Key('ChildA')), findsOneWidget);
-      expect(find.byKey(const Key('ChildB')), findsOneWidget);
-
-      expect(
-        tester.getSize(find.byKey(const Key('ChildA'))).width,
-        equals(499.0),
-      );
-      expect(
-        tester.getSize(find.byKey(const Key('ChildB'))).width,
-        equals(499.0),
+        equals((1000 - 2) * 1 / 3),
       );
 
       await tester.tap(find.byKey(const Key('ToggleSwitch')));
@@ -334,9 +253,7 @@ void main() {
 }
 
 class _ToggleChildApp extends StatefulWidget {
-  const _ToggleChildApp({required this.expand});
-
-  final bool expand;
+  const _ToggleChildApp();
 
   @override
   State<_ToggleChildApp> createState() => __ToggleChildAppState();
@@ -361,16 +278,15 @@ class __ToggleChildAppState extends State<_ToggleChildApp> {
         body: ResizableContainer(
           direction: Axis.horizontal,
           children: [
-            ResizableChild(
-              startingSize: const ResizableSize.ratio(0.5),
-              expand: widget.expand,
-              child: const SizedBox.expand(
+            const ResizableChild(
+              size: ResizableSize.expand(flex: 2),
+              child: SizedBox.expand(
                 key: Key('ChildA'),
               ),
             ),
             if (!hidden)
               const ResizableChild(
-                startingSize: ResizableSize.ratio(0.5),
+                size: ResizableSize.expand(),
                 child: SizedBox.expand(
                   key: Key('ChildB'),
                 ),

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -6,27 +6,29 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group(ResizableController, () {
     late ResizableController controller;
+    late ResizableControllerManager manager;
 
     setUp(() {
       controller = ResizableController();
+      manager = ResizableControllerManager(controller);
     });
 
     tearDown(() => controller.dispose());
 
     group('.sizes', () {
       setUp(() {
-        controller.setChildren(const [
+        manager.setChildren(const [
           ResizableChild(
-            startingSize: ResizableSize.pixels(100),
+            size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: ResizableSize.pixels(200),
+            size: ResizableSize.pixels(200),
             child: SizedBox.shrink(),
           ),
         ]);
 
-        controller.setAvailableSpace(300);
+        manager.setAvailableSpace(300);
       });
 
       test('returns a list of sizes', () {
@@ -36,18 +38,18 @@ void main() {
 
     group('.ratios', () {
       setUp(() {
-        controller.setChildren(const [
+        manager.setChildren(const [
           ResizableChild(
-            startingSize: ResizableSize.pixels(100),
+            size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: ResizableSize.pixels(200),
+            size: ResizableSize.pixels(200),
             child: SizedBox.shrink(),
           ),
         ]);
 
-        controller.setAvailableSpace(300);
+        manager.setAvailableSpace(300);
       });
 
       test('returns a list of ratios', () {
@@ -58,25 +60,25 @@ void main() {
     group('#setAvailableSpace', () {
       group('when the new value is the same', () {
         setUp(() {
-          controller.setChildren(const [
+          manager.setChildren(const [
             ResizableChild(
-              startingSize: ResizableSize.pixels(100),
+              size: ResizableSize.pixels(100),
               child: SizedBox.shrink(),
             ),
             ResizableChild(
-              startingSize: ResizableSize.pixels(200),
+              size: ResizableSize.pixels(200),
               child: SizedBox.shrink(),
             ),
           ]);
 
-          controller.setAvailableSpace(300);
+          manager.setAvailableSpace(300);
         });
 
         test('does not notify listeners', () {
           var notified = false;
           controller.addListener(() => notified = true);
 
-          controller.setAvailableSpace(300);
+          manager.setAvailableSpace(300);
 
           expect(notified, isFalse);
         });
@@ -84,13 +86,13 @@ void main() {
 
       group('when setting the value for the first time', () {
         setUp(() {
-          controller.setChildren(const [
+          manager.setChildren(const [
             ResizableChild(
-              startingSize: ResizableSize.pixels(100),
+              size: ResizableSize.pixels(100),
               child: SizedBox.shrink(),
             ),
             ResizableChild(
-              startingSize: ResizableSize.ratio(1 / 2),
+              size: ResizableSize.ratio(1 / 2),
               child: SizedBox.shrink(),
             ),
             ResizableChild(child: SizedBox.shrink()),
@@ -98,44 +100,44 @@ void main() {
         });
 
         test('sets sizes based on child starting size', () {
-          controller.setAvailableSpace(300);
+          manager.setAvailableSpace(300);
           expect(controller.sizes, equals([100, 100, 100]));
         });
 
         test('notifies listeners', () {
           var notified = false;
           controller.addListener(() => notified = true);
-          controller.setAvailableSpace(300);
+          manager.setAvailableSpace(300);
           expect(notified, isTrue);
         });
       });
 
       group('when updating the available space', () {
         setUp(() {
-          controller.setChildren(const [
+          manager.setChildren(const [
             ResizableChild(
-              startingSize: ResizableSize.pixels(100),
+              size: ResizableSize.pixels(100),
               child: SizedBox.shrink(),
             ),
             ResizableChild(
-              startingSize: ResizableSize.ratio(1 / 2),
+              size: ResizableSize.ratio(1 / 2),
               child: SizedBox.shrink(),
             ),
             ResizableChild(child: SizedBox.shrink()),
           ]);
 
-          controller.setAvailableSpace(300);
+          manager.setAvailableSpace(300);
         });
 
         test('adjusts child sizes', () {
-          controller.setAvailableSpace(600);
+          manager.setAvailableSpace(600);
           expect(controller.sizes, equals([200, 200, 200]));
         });
 
         test('notifies listeners', () {
           var notified = false;
           controller.addListener(() => notified = true);
-          controller.setAvailableSpace(600);
+          manager.setAvailableSpace(600);
           expect(notified, isTrue);
         });
       });
@@ -143,9 +145,9 @@ void main() {
 
     group('#setChildren', () {
       test('sets the list of ResizableChild', () {
-        controller.setChildren(const [
+        manager.setChildren(const [
           ResizableChild(
-            startingSize: ResizableSize.pixels(100),
+            size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
           ),
         ]);
@@ -155,7 +157,7 @@ void main() {
           equals(
             const [
               ResizableChild(
-                startingSize: ResizableSize.pixels(100),
+                size: ResizableSize.pixels(100),
                 child: SizedBox.shrink(),
               ),
             ],
@@ -166,9 +168,9 @@ void main() {
       test('does not notify listeners', () {
         var notified = false;
         controller.addListener(() => notified = true);
-        controller.setChildren(const [
+        manager.setChildren(const [
           ResizableChild(
-            startingSize: ResizableSize.pixels(100),
+            size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
           ),
         ]);
@@ -178,32 +180,29 @@ void main() {
 
     group('#updateChildren', () {
       setUp(() {
-        controller.setChildren(const [
+        manager.setChildren(const [
           ResizableChild(
-            startingSize: ResizableSize.pixels(100),
+            size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
         ]);
 
-        controller.setAvailableSpace(200);
+        manager.setAvailableSpace(200);
       });
 
       test('sets the list of children', () {
-        controller.updateChildren(const [
+        manager.updateChildren(const [
           ResizableChild(
-            startingSize: ResizableSize.pixels(100),
+            size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
         ]);
@@ -215,17 +214,15 @@ void main() {
       });
 
       test('updates children sizes', () {
-        controller.updateChildren(const [
+        manager.updateChildren(const [
           ResizableChild(
-            startingSize: ResizableSize.pixels(100),
+            size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
         ]);
@@ -236,17 +233,15 @@ void main() {
       test('does not notify listeners', () {
         var notified = false;
         controller.addListener(() => notified = true);
-        controller.updateChildren(const [
+        manager.updateChildren(const [
           ResizableChild(
-            startingSize: ResizableSize.pixels(100),
+            size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
         ]);
@@ -257,39 +252,37 @@ void main() {
 
     group('#adjustChildSize', () {
       setUp(() {
-        controller.setChildren(const [
+        manager.setChildren(const [
           ResizableChild(
-            startingSize: ResizableSize.pixels(100),
+            size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
         ]);
 
-        controller.setAvailableSpace(200);
+        manager.setAvailableSpace(200);
       });
 
       group('when increasing the size', () {
         test('increases the size of the target child', () {
-          controller.adjustChildSize(index: 1, delta: 10);
+          manager.adjustChildSize(index: 1, delta: 10);
           expect(controller.sizes[1], equals(60));
         });
 
         test('decreases the size of the adjacent child', () {
-          controller.adjustChildSize(index: 1, delta: 10);
+          manager.adjustChildSize(index: 1, delta: 10);
           expect(controller.sizes[2], equals(40));
         });
 
         test('notifies listeners', () {
           var notified = false;
           controller.addListener(() => notified = true);
-          controller.adjustChildSize(index: 1, delta: 10);
+          manager.adjustChildSize(index: 1, delta: 10);
           expect(notified, isTrue);
         });
       });
@@ -297,22 +290,20 @@ void main() {
 
     group('#setSizes', () {
       setUp(() {
-        controller.setChildren(const [
+        manager.setChildren(const [
           ResizableChild(
-            startingSize: ResizableSize.pixels(100),
+            size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
           ResizableChild(
-            startingSize: null,
             child: SizedBox.shrink(),
           ),
         ]);
 
-        controller.setAvailableSpace(200);
+        manager.setAvailableSpace(200);
       });
 
       group('when the list is the wrong length', () {
@@ -357,7 +348,7 @@ void main() {
         controller.setSizes(const [
           ResizableSize.pixels(100),
           ResizableSize.ratio(0.5),
-          null,
+          ResizableSize.expand(),
         ]);
 
         expect(controller.sizes, equals([100, 50, 50]));

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -130,8 +130,12 @@ void main() {
         });
 
         test('adjusts child sizes', () {
+          // only the "expandable" child (last) should change
+          final expected = [...controller.sizes];
+          expected.last += 300;
+
           manager.setAvailableSpace(600);
-          expect(controller.sizes, equals([200, 200, 200]));
+          expect(controller.sizes, equals(expected));
         });
 
         test('notifies listeners', () {


### PR DESCRIPTION
This PR adds a new `ResizableSize` ctor that represents an expanding/flexible size. This new size type replaces the `null` sizes in the controller to indicate which children should auto-fill the available space.

This new ctor takes an optional `flex` parameter that acts like the `flex` param of a `Flexible` or `Expanded` widget.