### PR TITLE
fix: Marked dirty during build exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-beta.4
+
+- Fix a bug in the "available size" initialization that was throwing a "marked dirty during build" exception
+
 ## 2.0.0-beta.3
 
 - Add a `ResizableSize.expand` constructor that takes a `flex` integer (defaults to 1)
@@ -117,7 +121,3 @@ First stable version!
 
   - Container resizes and enforces child size constraints (if present)
   - Resize cursor responds to user clicks and drags on web
-
-**TODO**
-
-  - Add documentation, code comments, and examples  

--- a/example/lib/screens/controller_listen/controller_listen_example_screen.dart
+++ b/example/lib/screens/controller_listen/controller_listen_example_screen.dart
@@ -25,11 +25,9 @@ class _ControllerListenExampleScreenState
     super.initState();
     controller.addListener(() {
       final sizes = controller.sizes;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        setState(() {
-          leftWidth = sizes.first;
-          rightWidth = sizes.last;
-        });
+      setState(() {
+        leftWidth = sizes.first;
+        rightWidth = sizes.last;
       });
     });
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-beta.3"
+    version: "2.0.0-beta.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.0.0-beta.3
+version: 2.0.0-beta.4
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -97,13 +97,17 @@ class ResizableController with ChangeNotifier {
     }
 
     if (_availableSpace == -1) {
+      // Initialize the child sizes and available space, but do not notify
+      // listeners; this step only occurs during the initial build, so we do
+      // not need to trigger another build
       _initializeChildSizes(availableSpace);
+      _availableSpace = availableSpace;
     } else {
+      // Update the child sizes to the new space and notify listeners
       _updateChildSizes(availableSpace);
+      _availableSpace = availableSpace;
+      notifyListeners();
     }
-
-    _availableSpace = availableSpace;
-    notifyListeners();
   }
 
   void _setChildren(List<ResizableChild> children) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_resizable_container
 description: Add nestable, resizable containers to your Flutter app with ease.
-version: 2.0.0-beta.3
+version: 2.0.0-beta.4
 homepage: https://github.com/andyhorn/flutter_resizable_container
 
 environment:

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -104,11 +104,11 @@ void main() {
           expect(controller.sizes, equals([100, 100, 100]));
         });
 
-        test('notifies listeners', () {
+        test('does not notify listeners', () {
           var notified = false;
           controller.addListener(() => notified = true);
           manager.setAvailableSpace(300);
-          expect(notified, isTrue);
+          expect(notified, isFalse);
         });
       });
 


### PR DESCRIPTION
This PR fixes a bug that was causing the app to throw a "marked dirty during build" exception if the user listened to the controller and updated state in the listener.