### PR TITLE
feat: expose drag event

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,6 @@
+**.dart_tool
+**.idea
+**build
+**/macos
+**/web
+**/windows

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each example also comes with an embedded source-code view, so you don't have to 
 
 - `ResizableContainer`s are fully nestable
 - Customize the length, thickness, alignment, and color of the divider(s) between children
-- Respond to user interactions with `onHoverEnter` and `onHoverExit` callbacks on dividers
+- Respond to user interactions with `onHoverEnter`, `onHoverExit`, `onDragStart`, and `onDragEnd` callbacks on dividers
 - Programmatically set the ratios of the resizable children through a `ResizableController`
 - Respond to changes in the sizes of the resizable children by listening to the `ResizableController`
 
@@ -243,7 +243,7 @@ In this scenario, the first child would be given 2/3 of the total available spac
 
 Use the `ResizableDivider` class to customize the look and feel of the dividers between each of a container's children.
 
-You can customize the `thickness`, `length`, `crossAxisAlignment`, `mainAxisAlignment`, and `color` of the divider. You can also provide callbacks for the `onHoverEnter` and `onHoverExit` events to respond to user interactions.
+You can customize the `thickness`, `length`, `crossAxisAlignment`, `mainAxisAlignment`, and `color` of the divider. You can also provide callbacks for the `onHoverEnter`, `onHoverExit`, `onDragStart`, and `onDragEnd` events to respond to user interactions.
 
 ```dart
 divider: ResizableDivider(
@@ -252,6 +252,8 @@ divider: ResizableDivider(
     length: const ResizableSize.ratio(0.25),
     onHoverEnter: () => setState(() => hovered = true),
     onHoverExit: () => setState(() => hovered = false),
+    onDragStart: () => setState(() => dragging = true),
+    onDragEnd: () => setState(() => dragging = false),
     color: hovered ? Colors.blue : Colors.black,
 ),
 ```

--- a/lib/src/resizable_container_divider.dart
+++ b/lib/src/resizable_container_divider.dart
@@ -120,6 +120,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   void _onVerticalDragStart(DragStartDetails _) {
     if (widget.direction == Axis.vertical) {
       setState(() => isDragging = true);
+      widget.config.onDragStart?.call();
     }
   }
 
@@ -132,6 +133,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   void _onVerticalDragEnd(DragEndDetails _) {
     if (widget.direction == Axis.vertical) {
       setState(() => isDragging = false);
+      widget.config.onDragEnd?.call();
 
       if (!isHovered) {
         widget.config.onHoverExit?.call();
@@ -142,6 +144,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   void _onHorizontalDragStart(DragStartDetails _) {
     if (widget.direction == Axis.horizontal) {
       setState(() => isDragging = true);
+      widget.config.onDragStart?.call();
     }
   }
 
@@ -154,6 +157,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   void _onHorizontalDragEnd(DragEndDetails _) {
     if (widget.direction == Axis.horizontal) {
       setState(() => isDragging = false);
+      widget.config.onDragEnd?.call();
 
       if (!isHovered) {
         widget.config.onHoverExit?.call();

--- a/lib/src/resizable_divider.dart
+++ b/lib/src/resizable_divider.dart
@@ -9,6 +9,8 @@ class ResizableDivider {
     this.color,
     this.onHoverEnter,
     this.onHoverExit,
+    this.onDragStart,
+    this.onDragEnd,
     this.mainAxisAlignment = MainAxisAlignment.center,
     this.crossAxisAlignment = CrossAxisAlignment.center,
   }) : assert(thickness > 0, '[thickness] must be > 0.');
@@ -55,4 +57,10 @@ class ResizableDivider {
 
   /// Triggers when the user's cursor ends hovering over this divider.
   final VoidCallback? onHoverExit;
+
+  /// Triggers when the user begins dragging this divider.
+  final VoidCallback? onDragStart;
+
+  /// Triggers when the user stops dragging this divider.
+  final VoidCallback? onDragEnd;
 }


### PR DESCRIPTION
Exposes drag events on the `ResizableDivider`.

Great for use cases where the children widgets need to adapt based on if they are being actively resized.