### PR TITLE
Make `ResizableController.setChildren()` public

### DIFF
--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -45,7 +45,7 @@ class _ResizableContainerState extends State<ResizableContainer> {
   late final controller = widget.controller ?? ResizableController();
   late final isDefaultController = widget.controller == null;
   late final manager = ResizableControllerManager(controller);
-  late final keys = List.generate(
+  late List<GlobalKey> keys = List.generate(
     widget.children.length,
     (_) => GlobalKey(),
   );
@@ -62,10 +62,15 @@ class _ResizableContainerState extends State<ResizableContainer> {
 
   @override
   void didUpdateWidget(covariant ResizableContainer oldWidget) {
-    final hasChanges = !listEquals(oldWidget.children, widget.children);
+    final hasChanges = !listEquals(oldWidget.children, widget.children)
+      || oldWidget.direction != widget.direction;
 
     if (hasChanges) {
       manager.updateChildren(widget.children);
+      keys = List.generate(
+        widget.children.length,
+        (_) => GlobalKey(),
+      );
     }
 
     super.didUpdateWidget(oldWidget);

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -57,7 +57,7 @@ class _ResizableContainerState extends State<ResizableContainer> {
   void initState() {
     super.initState();
 
-    manager.setChildren(widget.children);
+    controller.setChildren(widget.children);
   }
 
   @override

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -67,6 +67,8 @@ class ResizableController with ChangeNotifier {
   /// * The sum of all ratio values exceeds 1.0
   void setSizes(List<ResizableSize> values) {
     if (values.length != _children.length) {
+      print(values.length);
+      print(_children.length);
       throw ArgumentError('Must contain a value for every child');
     }
 
@@ -112,7 +114,6 @@ class ResizableController with ChangeNotifier {
 
   void setChildren(List<ResizableChild> children) {
     _children = children;
-    notifyListeners();
   }
 
   void _updateChildren(List<ResizableChild> children) {

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -67,7 +67,7 @@ class ResizableController with ChangeNotifier {
   /// * The sum of all ratio values exceeds 1.0
   void setSizes(List<ResizableSize> values) {
     if (values.length != _children.length) {
-      throw ArgumentError('Must contain a value for every child. Children: ${_children.length}, Ratios: ${values.length}');
+      throw ArgumentError('Must contain a value for every child. Children: ${_children.length}, Sizes: ${values.length}');
     }
 
     _sizes = _mapSizesToAvailableSpace(
@@ -114,7 +114,7 @@ class ResizableController with ChangeNotifier {
     _children = children;
   }
 
-  void updateChildren(List<ResizableChild> children) {
+  void _updateChildren(List<ResizableChild> children) {
     _children = children;
     _initializeChildSizes(_availableSpace);
   }
@@ -238,7 +238,7 @@ class ResizableController with ChangeNotifier {
     return delta;
   }
 
-  void notify() {
+  void _notify() {
     notifyListeners();
   }
 }
@@ -253,7 +253,7 @@ final class ResizableControllerManager {
   }
 
   void updateChildren(List<ResizableChild> children) {
-    _controller.updateChildren(children);
+    _controller._updateChildren(children);
   }
 
   void adjustChildSize({
@@ -268,7 +268,7 @@ final class ResizableControllerManager {
       _controller._sizes[i] = sizes[i];
     }
 
-    _controller.notify();
+    _controller._notify();
   }
 }
 

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -67,8 +67,6 @@ class ResizableController with ChangeNotifier {
   /// * The sum of all ratio values exceeds 1.0
   void setSizes(List<ResizableSize> values) {
     if (values.length != _children.length) {
-      print(values.length);
-      print(_children.length);
       throw ArgumentError('Must contain a value for every child');
     }
 

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -2,6 +2,7 @@ import "dart:collection";
 import "dart:math";
 
 import 'package:flutter/material.dart';
+import "package:flutter/scheduler.dart";
 import "package:flutter_resizable_container/flutter_resizable_container.dart";
 import "package:flutter_resizable_container/src/extensions/iterable_ext.dart";
 import "package:flutter_resizable_container/src/resizable_size.dart";
@@ -67,7 +68,7 @@ class ResizableController with ChangeNotifier {
   /// * The sum of all ratio values exceeds 1.0
   void setSizes(List<ResizableSize> values) {
     if (values.length != _children.length) {
-      throw ArgumentError('Must contain a value for every child');
+      throw ArgumentError('Must contain a value for every child. Children: ${_children.length}, Ratios: ${values.length}');
     }
 
     _sizes = _mapSizesToAvailableSpace(
@@ -114,7 +115,7 @@ class ResizableController with ChangeNotifier {
     _children = children;
   }
 
-  void _updateChildren(List<ResizableChild> children) {
+  void updateChildren(List<ResizableChild> children) {
     _children = children;
     _initializeChildSizes(_availableSpace);
   }
@@ -142,7 +143,7 @@ class ResizableController with ChangeNotifier {
       throw ArgumentError('Size cannot exceed total available space.');
     }
 
-    if (resizableSizes.totalRatio > 1.0) {
+    if (resizableSizes.totalRatio > 1.01) {
       throw ArgumentError('Ratios cannot exceed 1.0');
     }
 
@@ -165,7 +166,6 @@ class ResizableController with ChangeNotifier {
 
   void _updateChildSizes(double availableSpace) {
     final flexCount = _children.map((child) => child.size).flexCount;
-
     if (flexCount > 0) {
       // If any children are set to expand, adjust them instead of any
       // statically-sized children
@@ -239,7 +239,7 @@ class ResizableController with ChangeNotifier {
     return delta;
   }
 
-  void _notify() {
+  void notify() {
     notifyListeners();
   }
 }
@@ -254,7 +254,7 @@ final class ResizableControllerManager {
   }
 
   void updateChildren(List<ResizableChild> children) {
-    _controller._updateChildren(children);
+    _controller.updateChildren(children);
   }
 
   void adjustChildSize({
@@ -269,7 +269,7 @@ final class ResizableControllerManager {
       _controller._sizes[i] = sizes[i];
     }
 
-    _controller._notify();
+    _controller.notify();
   }
 }
 

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -110,8 +110,9 @@ class ResizableController with ChangeNotifier {
     }
   }
 
-  void _setChildren(List<ResizableChild> children) {
+  void setChildren(List<ResizableChild> children) {
     _children = children;
+    notifyListeners();
   }
 
   void _updateChildren(List<ResizableChild> children) {
@@ -251,10 +252,6 @@ final class ResizableControllerManager {
 
   void setAvailableSpace(double availableSpace) {
     _controller._setAvailableSpace(availableSpace);
-  }
-
-  void setChildren(List<ResizableChild> children) {
-    _controller._setChildren(children);
   }
 
   void updateChildren(List<ResizableChild> children) {

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -2,7 +2,6 @@ import "dart:collection";
 import "dart:math";
 
 import 'package:flutter/material.dart';
-import "package:flutter/scheduler.dart";
 import "package:flutter_resizable_container/flutter_resizable_container.dart";
 import "package:flutter_resizable_container/src/extensions/iterable_ext.dart";
 import "package:flutter_resizable_container/src/resizable_size.dart";

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_resizable_container/src/resizable_controller.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   group(ResizableController, () {
     late ResizableController controller;
     late ResizableControllerManager manager;

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -17,7 +17,7 @@ void main() {
 
     group('.sizes', () {
       setUp(() {
-        manager.setChildren(const [
+        controller.setChildren(const [
           ResizableChild(
             size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
@@ -38,7 +38,7 @@ void main() {
 
     group('.ratios', () {
       setUp(() {
-        manager.setChildren(const [
+        controller.setChildren(const [
           ResizableChild(
             size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
@@ -60,7 +60,7 @@ void main() {
     group('#setAvailableSpace', () {
       group('when the new value is the same', () {
         setUp(() {
-          manager.setChildren(const [
+          controller.setChildren(const [
             ResizableChild(
               size: ResizableSize.pixels(100),
               child: SizedBox.shrink(),
@@ -86,7 +86,7 @@ void main() {
 
       group('when setting the value for the first time', () {
         setUp(() {
-          manager.setChildren(const [
+          controller.setChildren(const [
             ResizableChild(
               size: ResizableSize.pixels(100),
               child: SizedBox.shrink(),
@@ -114,7 +114,7 @@ void main() {
 
       group('when updating the available space', () {
         setUp(() {
-          manager.setChildren(const [
+          controller.setChildren(const [
             ResizableChild(
               size: ResizableSize.pixels(100),
               child: SizedBox.shrink(),
@@ -149,7 +149,7 @@ void main() {
 
     group('#setChildren', () {
       test('sets the list of ResizableChild', () {
-        manager.setChildren(const [
+        controller.setChildren(const [
           ResizableChild(
             size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
@@ -172,7 +172,7 @@ void main() {
       test('does not notify listeners', () {
         var notified = false;
         controller.addListener(() => notified = true);
-        manager.setChildren(const [
+        controller.setChildren(const [
           ResizableChild(
             size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
@@ -184,7 +184,7 @@ void main() {
 
     group('#updateChildren', () {
       setUp(() {
-        manager.setChildren(const [
+        controller.setChildren(const [
           ResizableChild(
             size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
@@ -256,7 +256,7 @@ void main() {
 
     group('#adjustChildSize', () {
       setUp(() {
-        manager.setChildren(const [
+        controller.setChildren(const [
           ResizableChild(
             size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),
@@ -294,7 +294,7 @@ void main() {
 
     group('#setSizes', () {
       setUp(() {
-        manager.setChildren(const [
+        controller.setChildren(const [
           ResizableChild(
             size: ResizableSize.pixels(100),
             child: SizedBox.shrink(),

--- a/test/resizable_divider_test.dart
+++ b/test/resizable_divider_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_resizable_container/src/resizable_container_divider.dart
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  // WidgetsFlutterBinding.ensureInitialized();
   group(ResizableDivider, () {
     group('thickness', () {
       test('must be greater than 0', () {

--- a/test/resizable_divider_test.dart
+++ b/test/resizable_divider_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_resizable_container/src/resizable_container_divider.dart
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  // WidgetsFlutterBinding.ensureInitialized();
   group(ResizableDivider, () {
     group('thickness', () {
       test('must be greater than 0', () {

--- a/test/resizable_size_test.dart
+++ b/test/resizable_size_test.dart
@@ -1,7 +1,9 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/src/resizable_size.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   group(ResizableSize, () {
     group('constructor', () {
       group('ratio', () {


### PR DESCRIPTION
My use case is that I have a widget that has a lot of nested containers and controllers. We offer a button to save the current setup as a preset, then load it in later. To do this, we need to be able to set the content and ratios of each controller exactly. However, this presents a problem since we often need to change the number of children each controller has: we can only change the content during the `build()` function, and need to set the ratios before or after. Sometimes, the controller may be hidden entirely, meaning assigning any ratios to it at all will cause an error.

The fundamental problem here is that we were managing the ratios in our model and the children in our UI, and they were prone to being out-of-sync. By making `setChildren()` public, I was able to have the model set all the children to blank `Container`s with their respective ratios, which eliminates all errors even before my `build()` function runs again. 

I tried adding a call to `notifyListeners()`, but that made the tests fail so I removed it. Curious why that's not allowed there. I also removed `ResizableControllerManager.setChildren` since it seems like that was only being used for testing, and it seems proper to me to test the public API instead. 