### PR TITLE
ref: convert ResizableSize to sealed class

### DIFF
--- a/lib/src/extensions/iterable_ext.dart
+++ b/lib/src/extensions/iterable_ext.dart
@@ -1,5 +1,3 @@
-import 'package:flutter_resizable_container/flutter_resizable_container.dart';
-
 extension IterableNumExtensions on Iterable<num> {
   num sum() => fold(0, (sum, current) => sum + current);
 }
@@ -21,13 +19,4 @@ extension IterableExtensions<T> on Iterable<T> {
           ],
         ],
       ];
-}
-
-extension ResizableSizeIterableExtensions on Iterable<ResizableSize> {
-  double get totalPixels =>
-      where((size) => size.isPixels).sum((size) => size.value).toDouble();
-  double get totalRatio =>
-      where((size) => size.isRatio).sum((size) => size.value).toDouble();
-  int get flexCount =>
-      where((size) => size.isExpand).sum((size) => size.value).toInt();
 }

--- a/lib/src/resizable_container_divider.dart
+++ b/lib/src/resizable_container_divider.dart
@@ -94,11 +94,11 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
 
   double _getHeight(double maxHeight) {
     return switch (widget.direction) {
-      Axis.horizontal => switch (widget.config.length.type) {
-          SizeType.pixels => min(widget.config.length.value, maxHeight),
-          SizeType.expand => maxHeight,
-          SizeType.ratio => maxHeight * widget.config.length.value,
-          SizeType.shrink => 0.0,
+      Axis.horizontal => switch (widget.config.length) {
+          ResizableSizePixels(:final pixels) => min(pixels, maxHeight),
+          ResizableSizeExpand() => maxHeight,
+          ResizableSizeRatio(:final ratio) => maxHeight * ratio,
+          ResizableSizeShrink() => 0.0,
         },
       Axis.vertical => widget.config.thickness + widget.config.padding,
     };
@@ -107,11 +107,11 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   double _getWidth(double maxWidth) {
     return switch (widget.direction) {
       Axis.horizontal => widget.config.thickness + widget.config.padding,
-      Axis.vertical => switch (widget.config.length.type) {
-          SizeType.pixels => min(widget.config.length.value, maxWidth),
-          SizeType.expand => maxWidth,
-          SizeType.ratio => maxWidth * widget.config.length.value,
-          SizeType.shrink => 0.0,
+      Axis.vertical => switch (widget.config.length) {
+          ResizableSizePixels(:final pixels) => min(pixels, maxWidth),
+          ResizableSizeExpand() => maxWidth,
+          ResizableSizeRatio(:final ratio) => maxWidth * ratio,
+          ResizableSizeShrink() => 0.0,
         },
     };
   }

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -3,6 +3,7 @@ import "dart:math";
 
 import 'package:flutter/material.dart';
 import "package:flutter_resizable_container/flutter_resizable_container.dart";
+import "package:flutter_resizable_container/src/resizable_size.dart";
 
 /// A controller to provide a programmatic interface to a [ResizableContainer].
 class ResizableController with ChangeNotifier {
@@ -34,8 +35,8 @@ class ResizableController with ChangeNotifier {
     }
 
     final totalPixels = sizes
-        .where((size) => size.isPixels)
-        .fold(0.0, (sum, curr) => sum + curr.value);
+        .whereType<ResizableSizePixels>()
+        .fold(0.0, (sum, curr) => sum + curr.pixels);
 
     if (totalPixels > _availableSpace) {
       throw ArgumentError(
@@ -44,8 +45,8 @@ class ResizableController with ChangeNotifier {
     }
 
     final totalRatio = sizes
-        .where((size) => size.isRatio)
-        .fold(0.0, (sum, curr) => sum + curr.value);
+        .whereType<ResizableSizeRatio>()
+        .fold(0.0, (sum, curr) => sum + curr.ratio);
 
     if (totalRatio > 1.0) {
       throw ArgumentError('Total ratio must be less than or equal to 1.0');
@@ -245,7 +246,7 @@ class ResizableController with ChangeNotifier {
     }
 
     for (final index in indices) {
-      if (!_children[index].size.isExpand) {
+      if (_children[index].size is! ResizableSizeExpand) {
         continue;
       }
 

--- a/lib/src/resizable_size.dart
+++ b/lib/src/resizable_size.dart
@@ -1,51 +1,70 @@
-enum SizeType {
-  ratio,
-  pixels,
-  expand,
-  shrink,
+sealed class ResizableSize {
+  const ResizableSize._();
+
+  const factory ResizableSize.pixels(double pixels) = ResizableSizePixels;
+  const factory ResizableSize.ratio(double ratio) = ResizableSizeRatio;
+  const factory ResizableSize.expand({int flex}) = ResizableSizeExpand;
+  const factory ResizableSize.shrink() = ResizableSizeShrink;
 }
 
-final class ResizableSize {
-  const ResizableSize.pixels(double pixels)
-      // ignore: prefer_initializing_formals
-      : _value = pixels,
-        type = SizeType.pixels,
-        assert(pixels >= 0, 'Value cannot be less than 0.');
+final class ResizableSizePixels extends ResizableSize {
+  const ResizableSizePixels(this.pixels)
+      : assert(pixels >= 0, 'pixels must be greater than or equal to 0'),
+        super._();
 
-  const ResizableSize.ratio(double ratio)
-      // ignore: prefer_initializing_formals
-      : _value = ratio,
-        type = SizeType.ratio,
-        assert(
-          ratio >= 0 && ratio <= 1,
-          'Value must be between 0 and 1, inclusive.',
-        );
-
-  const ResizableSize.expand({int flex = 1})
-      : _value = flex,
-        type = SizeType.expand,
-        assert(flex > 0, 'Flex value must be greater than 0.');
-
-  const ResizableSize.shrink()
-      : _value = 0,
-        type = SizeType.shrink;
-
-  final num _value;
-  final SizeType type;
-
-  double get value => _value.toDouble();
-  bool get isRatio => type == SizeType.ratio;
-  bool get isPixels => type == SizeType.pixels;
-  bool get isExpand => type == SizeType.expand;
-  bool get isShrink => type == SizeType.shrink;
+  final double pixels;
 
   @override
-  String toString() => 'ResizableSize(type: $type, value: $_value)';
+  String toString() => 'ResizableSizePixels($pixels)';
 
   @override
   operator ==(Object other) =>
-      other is ResizableSize && other.type == type && other._value == _value;
+      other is ResizableSizePixels && other.pixels == pixels;
 
   @override
-  int get hashCode => Object.hash(type, _value);
+  int get hashCode => pixels.hashCode;
+}
+
+final class ResizableSizeRatio extends ResizableSize {
+  const ResizableSizeRatio(this.ratio)
+      : assert(ratio >= 0, 'ratio must be greater than or equal to 0'),
+        assert(ratio <= 1, 'ratio must be less than or equal to 1'),
+        super._();
+
+  final double ratio;
+
+  @override
+  String toString() => 'ResizableSizeRatio($ratio)';
+
+  @override
+  operator ==(Object other) =>
+      other is ResizableSizeRatio && other.ratio == ratio;
+
+  @override
+  int get hashCode => ratio.hashCode;
+}
+
+final class ResizableSizeExpand extends ResizableSize {
+  const ResizableSizeExpand({this.flex = 1})
+      : assert(flex > 0, 'flex must be greater than 0'),
+        super._();
+
+  final int flex;
+
+  @override
+  String toString() => 'ResizableSizeExpand(flex: $flex)';
+
+  @override
+  operator ==(Object other) =>
+      other is ResizableSizeExpand && other.flex == flex;
+
+  @override
+  int get hashCode => flex.hashCode;
+}
+
+final class ResizableSizeShrink extends ResizableSize {
+  const ResizableSizeShrink() : super._();
+
+  @override
+  String toString() => 'ResizableSizeShrink()';
 }


### PR DESCRIPTION
Convert the `ResizableSize` class to a sealed base class and a set of derived classes.

This allows us to remove the `SizeType` enum and double -> int conversion, opting instead for discrete properties on the child classes and the use of pattern matching and destructuring to extract the values with the proper type.