### PR TITLE
ref: move the min/max bounds into ResizableSize

### DIFF
--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -161,7 +161,6 @@ class ResizableLayoutRenderObject extends RenderBox
       final constraints = _getChildConstraints(
         size: size,
         child: child,
-        resizableChild: resizableChildren[i ~/ 2],
         availableRatioSpace: availableRatioSpace,
         expandSpace: remainingExpandSpace,
         flexCount: flexCount,
@@ -200,7 +199,7 @@ class ResizableLayoutRenderObject extends RenderBox
     final pixels = [
       for (var i = 0; i < sizes.length; i++) ...[
         if (sizes[i] case ResizableSizePixels(:final pixels)) ...[
-          _clamp(pixels, resizableChildren[i]),
+          _clamp(pixels, sizes[i]),
         ],
       ],
     ];
@@ -214,7 +213,7 @@ class ResizableLayoutRenderObject extends RenderBox
         if (sizes[i] is ResizableSizeShrink) ...[
           _clamp(
             layoutDirection.getMinIntrinsicDimension(children[i * 2]),
-            resizableChildren[i],
+            sizes[i],
           ),
         ]
       ],
@@ -248,7 +247,7 @@ class ResizableLayoutRenderObject extends RenderBox
     final sizes = [
       for (var i = 0; i < this.sizes.length; i++) ...[
         if (this.sizes[i] case ResizableSizeRatio(:final ratio)) ...[
-          _clamp(ratio * availableSpace, resizableChildren[i]),
+          _clamp(ratio * availableSpace, this.sizes[i]),
         ],
       ],
     ];
@@ -278,7 +277,6 @@ class ResizableLayoutRenderObject extends RenderBox
 
   BoxConstraints _getChildConstraints({
     required ResizableSize size,
-    required ResizableChild resizableChild,
     required RenderBox child,
     required double availableRatioSpace,
     required double expandSpace,
@@ -291,17 +289,17 @@ class ResizableLayoutRenderObject extends RenderBox
       ResizableSizeExpand(:final flex) => flex * (expandSpace / flexCount),
     };
 
-    final clampedValue = _clamp(value, resizableChild);
+    final clampedValue = _clamp(value, size);
     final childSize = layoutDirection.getSize(clampedValue, constraints);
     final childConstraints = BoxConstraints.tight(childSize);
 
     return childConstraints;
   }
 
-  double _clamp(double value, ResizableChild resizableChild) {
+  double _clamp(double value, ResizableSize size) {
     return value.clamp(
-      resizableChild.minSize ?? 0,
-      resizableChild.maxSize ?? double.infinity,
+      size.min ?? 0,
+      size.max ?? double.infinity,
     );
   }
 

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -7,15 +7,7 @@ class ResizableChild {
   const ResizableChild({
     required this.child,
     this.size = const ResizableSize.expand(),
-    this.maxSize,
-    this.minSize,
   });
-
-  /// The (optional) maximum size (in px) of this child Widget.
-  final double? maxSize;
-
-  /// The (optional) minimum size (in px) of this child Widget.
-  final double? minSize;
 
   /// The size of the corresponding widget. May use a ratio of the
   /// available space, an absolute size in logical pixels, or it can
@@ -37,25 +29,14 @@ class ResizableChild {
   final Widget child;
 
   @override
-  String toString() => 'ResizableChildData('
-      'size: $size, '
-      'maxSize: $maxSize, '
-      'minSize: $minSize, '
-      'child: $child)';
+  String toString() => 'ResizableChildData(size: $size, child: $child)';
 
   @override
   operator ==(Object other) =>
       other is ResizableChild &&
       other.size == size &&
-      other.maxSize == maxSize &&
-      other.minSize == minSize &&
       other.child.runtimeType == child.runtimeType;
 
   @override
-  int get hashCode => Object.hash(
-        size,
-        maxSize,
-        minSize,
-        child,
-      );
+  int get hashCode => Object.hash(size, child);
 }

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -142,7 +142,7 @@ class ResizableController with ChangeNotifier {
   }
 
   double _getMinimumNecessarySize() {
-    final minimums = _children.map((child) => child.minSize ?? 0.0).toList();
+    final minimums = _sizes.map((size) => size.min ?? 0.0).toList();
     return minimums.fold(0.0, (sum, curr) => sum + curr);
   }
 
@@ -210,7 +210,7 @@ class ResizableController with ChangeNotifier {
     final targetSize = sizes[index] + delta;
 
     if (delta < 0) {
-      final minimumSize = _children[index].minSize ?? 0;
+      final minimumSize = _sizes[index].min ?? 0;
 
       if (targetSize <= minimumSize) {
         return minimumSize - sizes[index];
@@ -219,7 +219,7 @@ class ResizableController with ChangeNotifier {
       return delta;
     }
 
-    final maximumSize = _children[index].maxSize ?? double.infinity;
+    final maximumSize = _sizes[index].max ?? double.infinity;
 
     if (targetSize >= maximumSize) {
       return maximumSize - sizes[index];
@@ -233,8 +233,8 @@ class ResizableController with ChangeNotifier {
     final List<int> changeableIndices = [];
 
     bool shouldAdd(index) {
-      final minSize = _children[index].minSize ?? 0.0;
-      final maxSize = _children[index].maxSize ?? double.infinity;
+      final minSize = _sizes[index].min ?? 0.0;
+      final maxSize = _sizes[index].max ?? double.infinity;
 
       if (direction < 0 && sizes[index] > minSize) {
         return true;
@@ -273,9 +273,9 @@ class ResizableController with ChangeNotifier {
     required double delta,
   }) {
     final currentSize = pixels[index];
-    final minCurrentSize = _children[index].minSize ?? 0;
+    final minCurrentSize = _sizes[index].min ?? 0;
     final adjacentSize = pixels[index + 1];
-    final maxAdjacentSize = _children[index + 1].maxSize ?? double.infinity;
+    final maxAdjacentSize = _sizes[index + 1].max ?? double.infinity;
     final maxCurrentDelta = currentSize - minCurrentSize;
     final maxAdjacentDelta = maxAdjacentSize - adjacentSize;
     final maxDelta = min(maxCurrentDelta, maxAdjacentDelta);
@@ -292,9 +292,9 @@ class ResizableController with ChangeNotifier {
     required double delta,
   }) {
     final currentSize = pixels[index];
-    final maxCurrentSize = _children[index].maxSize ?? double.infinity;
+    final maxCurrentSize = _sizes[index].max ?? double.infinity;
     final adjacentSize = pixels[index + 1];
-    final minAdjacentSize = _children[index + 1].minSize ?? 0;
+    final minAdjacentSize = _sizes[index + 1].min ?? 0;
     final maxAvailableSpace = min(maxCurrentSize, _availableSpace);
     final maxCurrentDelta = maxAvailableSpace - currentSize;
     final maxAdjacentDelta = adjacentSize - minAdjacentSize;

--- a/lib/src/resizable_size.dart
+++ b/lib/src/resizable_size.dart
@@ -15,6 +15,10 @@ sealed class ResizableSize {
         assert(
           max == null || max < double.infinity,
           'max cannot be equal to infinity',
+        ),
+        assert(
+          min == null || max == null || min <= max,
+          'min must be less than or equal to max',
         );
 
   final double? min;

--- a/lib/src/resizable_size.dart
+++ b/lib/src/resizable_size.dart
@@ -1,14 +1,21 @@
 sealed class ResizableSize {
-  const ResizableSize._();
+  const ResizableSize._({this.min, this.max});
 
-  const factory ResizableSize.pixels(double pixels) = ResizableSizePixels;
-  const factory ResizableSize.ratio(double ratio) = ResizableSizeRatio;
-  const factory ResizableSize.expand({int flex}) = ResizableSizeExpand;
-  const factory ResizableSize.shrink() = ResizableSizeShrink;
+  final double? min;
+  final double? max;
+
+  const factory ResizableSize.pixels(double pixels,
+      {double? min, double? max}) = ResizableSizePixels;
+  const factory ResizableSize.ratio(double ratio, {double? min, double? max}) =
+      ResizableSizeRatio;
+  const factory ResizableSize.expand({int flex, double? min, double? max}) =
+      ResizableSizeExpand;
+  const factory ResizableSize.shrink({double? min, double? max}) =
+      ResizableSizeShrink;
 }
 
 final class ResizableSizePixels extends ResizableSize {
-  const ResizableSizePixels(this.pixels)
+  const ResizableSizePixels(this.pixels, {super.min, super.max})
       : assert(pixels >= 0, 'pixels must be greater than or equal to 0'),
         super._();
 
@@ -26,7 +33,7 @@ final class ResizableSizePixels extends ResizableSize {
 }
 
 final class ResizableSizeRatio extends ResizableSize {
-  const ResizableSizeRatio(this.ratio)
+  const ResizableSizeRatio(this.ratio, {super.min, super.max})
       : assert(ratio >= 0, 'ratio must be greater than or equal to 0'),
         assert(ratio <= 1, 'ratio must be less than or equal to 1'),
         super._();
@@ -45,7 +52,7 @@ final class ResizableSizeRatio extends ResizableSize {
 }
 
 final class ResizableSizeExpand extends ResizableSize {
-  const ResizableSizeExpand({this.flex = 1})
+  const ResizableSizeExpand({this.flex = 1, super.min, super.max})
       : assert(flex > 0, 'flex must be greater than 0'),
         super._();
 
@@ -63,7 +70,7 @@ final class ResizableSizeExpand extends ResizableSize {
 }
 
 final class ResizableSizeShrink extends ResizableSize {
-  const ResizableSizeShrink() : super._();
+  const ResizableSizeShrink({super.min, super.max}) : super._();
 
   @override
   String toString() => 'ResizableSizeShrink()';

--- a/lib/src/resizable_size.dart
+++ b/lib/src/resizable_size.dart
@@ -1,17 +1,47 @@
 sealed class ResizableSize {
-  const ResizableSize._({this.min, this.max});
+  const ResizableSize._({this.min, this.max})
+      : assert(
+          min == null || min >= 0,
+          'min must be greater than or equal to 0',
+        ),
+        assert(
+          min == null || min < double.infinity,
+          'min cannot be equal to infinity',
+        ),
+        assert(
+          max == null || max >= 0,
+          'max must be greater than or equal to 0',
+        ),
+        assert(
+          max == null || max < double.infinity,
+          'max cannot be equal to infinity',
+        );
 
   final double? min;
   final double? max;
 
-  const factory ResizableSize.pixels(double pixels,
-      {double? min, double? max}) = ResizableSizePixels;
-  const factory ResizableSize.ratio(double ratio, {double? min, double? max}) =
-      ResizableSizeRatio;
-  const factory ResizableSize.expand({int flex, double? min, double? max}) =
-      ResizableSizeExpand;
-  const factory ResizableSize.shrink({double? min, double? max}) =
-      ResizableSizeShrink;
+  const factory ResizableSize.pixels(
+    double pixels, {
+    double? min,
+    double? max,
+  }) = ResizableSizePixels;
+
+  const factory ResizableSize.ratio(
+    double ratio, {
+    double? min,
+    double? max,
+  }) = ResizableSizeRatio;
+
+  const factory ResizableSize.expand({
+    int flex,
+    double? min,
+    double? max,
+  }) = ResizableSizeExpand;
+
+  const factory ResizableSize.shrink({
+    double? min,
+    double? max,
+  }) = ResizableSizeShrink;
 }
 
 final class ResizableSizePixels extends ResizableSize {

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -198,8 +198,7 @@ void main() {
                 direction: Axis.horizontal,
                 children: [
                   ResizableChild(
-                    size: ResizableSize.ratio(0.25),
-                    minSize: 400,
+                    size: ResizableSize.ratio(0.25, min: 400),
                     child: SizedBox.expand(
                       key: Key('BoxA'),
                     ),
@@ -235,8 +234,7 @@ void main() {
                 direction: Axis.horizontal,
                 children: [
                   ResizableChild(
-                    size: ResizableSize.ratio(0.75),
-                    maxSize: 400,
+                    size: ResizableSize.ratio(0.75, max: 400),
                     child: SizedBox.expand(
                       key: Key('BoxA'),
                     ),
@@ -272,8 +270,7 @@ void main() {
                 direction: Axis.horizontal,
                 children: [
                   ResizableChild(
-                    size: ResizableSize.pixels(400),
-                    minSize: 500,
+                    size: ResizableSize.pixels(400, min: 500),
                     child: SizedBox.expand(
                       key: Key('BoxA'),
                     ),
@@ -309,8 +306,7 @@ void main() {
                 direction: Axis.horizontal,
                 children: [
                   ResizableChild(
-                    size: ResizableSize.pixels(400),
-                    maxSize: 300,
+                    size: ResizableSize.pixels(400, max: 300),
                     child: SizedBox.expand(
                       key: Key('BoxA'),
                     ),
@@ -346,8 +342,7 @@ void main() {
                 direction: Axis.horizontal,
                 children: [
                   ResizableChild(
-                    size: ResizableSize.shrink(),
-                    minSize: 500,
+                    size: ResizableSize.shrink(min: 500),
                     child: SizedBox(
                       width: 200,
                       key: Key('BoxA'),
@@ -384,8 +379,7 @@ void main() {
                 direction: Axis.horizontal,
                 children: [
                   ResizableChild(
-                    size: ResizableSize.shrink(),
-                    maxSize: 300,
+                    size: ResizableSize.shrink(max: 300),
                     child: SizedBox(
                       width: 400,
                       key: Key('BoxA'),
@@ -422,8 +416,7 @@ void main() {
                 direction: Axis.horizontal,
                 children: [
                   ResizableChild(
-                    size: ResizableSize.expand(),
-                    minSize: 700,
+                    size: ResizableSize.expand(min: 700),
                     child: SizedBox.expand(
                       key: Key('BoxA'),
                     ),
@@ -459,8 +452,7 @@ void main() {
                 direction: Axis.horizontal,
                 children: [
                   ResizableChild(
-                    size: ResizableSize.expand(),
-                    maxSize: 300,
+                    size: ResizableSize.expand(max: 300),
                     child: SizedBox.expand(
                       key: Key('BoxA'),
                     ),
@@ -603,7 +595,7 @@ void main() {
               direction: Axis.horizontal,
               children: [
                 ResizableChild(
-                  minSize: 200,
+                  size: ResizableSize.expand(min: 200),
                   child: SizedBox.expand(
                     key: Key('BoxA'),
                   ),
@@ -640,7 +632,7 @@ void main() {
               direction: Axis.horizontal,
               children: [
                 ResizableChild(
-                  maxSize: 700,
+                  size: ResizableSize.expand(max: 700),
                   child: SizedBox.expand(
                     key: Key('BoxA'),
                   ),
@@ -684,7 +676,7 @@ void main() {
               direction: Axis.horizontal,
               children: [
                 ResizableChild(
-                  minSize: 200,
+                  size: ResizableSize.expand(min: 200),
                   child: SizedBox.expand(
                     key: Key('BoxA'),
                   ),
@@ -941,8 +933,7 @@ void main() {
                         ),
                       ),
                       ResizableChild(
-                        size: ResizableSize.expand(),
-                        maxSize: 850,
+                        size: ResizableSize.expand(max: 850),
                         child: SizedBox(
                           key: Key('BoxB'),
                         ),

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -144,8 +144,7 @@ void main() {
                 child: SizedBox.shrink(),
               ),
               ResizableChild(
-                maxSize: 225.0,
-                size: ResizableSize.expand(),
+                size: ResizableSize.expand(max: 225),
                 child: SizedBox.shrink(),
               ),
             ]);


### PR DESCRIPTION
Move the min/max bounds out of the `ResizableChild` class and into the `ResizableSize` class.

This is a logical move to encapsulate all sizing configuration in the size class, instead of having some configuration in the size class and some in the child class.

Resolves #67.