### PR TITLE
fix: controller notifying during build

### DIFF
--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -46,7 +46,7 @@ class _ResizableContainerState extends State<ResizableContainer> {
   void initState() {
     super.initState();
 
-    controller.setChildren(widget.children);
+    manager.initChildren(widget.children);
   }
 
   @override

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -71,11 +71,22 @@ class ResizableController with ChangeNotifier {
   }
 
   void setChildren(List<ResizableChild> children) {
+    _setChildren(children, true);
+  }
+
+  void _initChildren(List<ResizableChild> children) {
+    _setChildren(children, false);
+  }
+
+  void _setChildren(List<ResizableChild> children, bool notify) {
     _children = children;
     _sizes = children.map((child) => child.size).toList();
     _pixels = List.filled(children.length, 0);
     _needsLayout = true;
-    notifyListeners();
+
+    if (notify) {
+      notifyListeners();
+    }
   }
 
   void _setRenderedSizes(List<double> pixels) {
@@ -327,6 +338,10 @@ final class ResizableControllerManager {
 
   void setNeedsLayout() {
     _controller._needsLayout = true;
+  }
+
+  void initChildren(List<ResizableChild> children) {
+    _controller._initChildren(children);
   }
 }
 

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -71,14 +71,14 @@ class ResizableController with ChangeNotifier {
   }
 
   void setChildren(List<ResizableChild> children) {
-    _setChildren(children, true);
+    _setChildren(children, notify: true);
   }
 
   void _initChildren(List<ResizableChild> children) {
-    _setChildren(children, false);
+    _setChildren(children, notify: false);
   }
 
-  void _setChildren(List<ResizableChild> children, bool notify) {
+  void _setChildren(List<ResizableChild> children, {required bool notify}) {
     _children = children;
     _sizes = children.map((child) => child.size).toList();
     _pixels = List.filled(children.length, 0);


### PR DESCRIPTION
This fixes #80 by using separate logic for the child initialization than for an update to the list of children during runtime.