### PR TITLE
fix: account for expand min/max bounds

### DIFF
--- a/example/lib/screens/divider/custom_divider_example_screen.dart
+++ b/example/lib/screens/divider/custom_divider_example_screen.dart
@@ -40,96 +40,119 @@ class _CustomDividerExampleScreenState
       drawer: const NavDrawer(),
       body: Column(
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          Wrap(
+            alignment: WrapAlignment.start,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            runSpacing: 18,
+            spacing: 18,
             children: [
-              Column(
-                children: [
-                  const Text('Length'),
-                  Slider(
-                    min: 0.01,
-                    max: 1.0,
-                    value: length,
-                    onChanged: (value) => setState(() => length = value),
-                  ),
-                  Text('Ratio: ${(length * 100).toStringAsFixed((2))}%'),
-                ],
-              ),
-              Column(
-                children: [
-                  const Text('Thickness'),
-                  Slider(
-                    min: 1,
-                    max: 20.0,
-                    divisions: 19,
-                    value: thickness,
-                    onChanged: (value) => setState(() => thickness = value),
-                  ),
-                  Text('${thickness}px'),
-                ],
-              ),
-              Column(
-                children: [
-                  const Text('Padding'),
-                  Slider(
-                    min: 0,
-                    max: 20,
-                    divisions: 20,
-                    value: padding,
-                    onChanged: (value) => setState(() => padding = value),
-                  ),
-                  Text('${padding}px'),
-                ],
-              ),
-              Column(
-                children: [
-                  const Text('Cross-Axis Alignment'),
-                  DropdownButton(
-                    value: crossAxisAlignment,
-                    items: const [
-                      DropdownMenuItem(
-                        value: CrossAxisAlignment.start,
-                        child: Text('Start'),
-                      ),
-                      DropdownMenuItem(
-                        value: CrossAxisAlignment.center,
-                        child: Text('Center'),
-                      ),
-                      DropdownMenuItem(
-                        value: CrossAxisAlignment.end,
-                        child: Text('End'),
-                      ),
-                    ],
-                    onChanged: (value) => setState(
-                      () => crossAxisAlignment = value!,
+              SizedBox(
+                width: 200,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Length'),
+                    Slider(
+                      min: 0.01,
+                      max: 1.0,
+                      value: length,
+                      onChanged: (value) => setState(() => length = value),
                     ),
-                  ),
-                ],
+                    Text('Ratio: ${(length * 100).toStringAsFixed((2))}%'),
+                  ],
+                ),
               ),
-              Column(
-                children: [
-                  const Text('Main-Axis Alignment'),
-                  DropdownButton(
-                    value: mainAxisAlignment,
-                    items: const [
-                      DropdownMenuItem(
-                        value: MainAxisAlignment.start,
-                        child: Text('Start'),
-                      ),
-                      DropdownMenuItem(
-                        value: MainAxisAlignment.center,
-                        child: Text('Center'),
-                      ),
-                      DropdownMenuItem(
-                        value: MainAxisAlignment.end,
-                        child: Text('End'),
-                      ),
-                    ],
-                    onChanged: (value) => setState(
-                      () => mainAxisAlignment = value!,
+              SizedBox(
+                width: 200,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Thickness'),
+                    Slider(
+                      min: 1,
+                      max: 20.0,
+                      divisions: 19,
+                      value: thickness,
+                      onChanged: (value) => setState(() => thickness = value),
                     ),
-                  ),
-                ],
+                    Text('${thickness}px'),
+                  ],
+                ),
+              ),
+              SizedBox(
+                width: 200,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Padding'),
+                    Slider(
+                      min: 0,
+                      max: 20,
+                      divisions: 20,
+                      value: padding,
+                      onChanged: (value) => setState(() => padding = value),
+                    ),
+                    Text('${padding}px'),
+                  ],
+                ),
+              ),
+              SizedBox(
+                width: 200,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Cross-Axis Alignment'),
+                    DropdownButton(
+                      value: crossAxisAlignment,
+                      items: const [
+                        DropdownMenuItem(
+                          value: CrossAxisAlignment.start,
+                          child: Text('Start'),
+                        ),
+                        DropdownMenuItem(
+                          value: CrossAxisAlignment.center,
+                          child: Text('Center'),
+                        ),
+                        DropdownMenuItem(
+                          value: CrossAxisAlignment.end,
+                          child: Text('End'),
+                        ),
+                      ],
+                      onChanged: (value) => setState(
+                        () => crossAxisAlignment = value!,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(
+                width: 200,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text('Main-Axis Alignment'),
+                    DropdownButton(
+                      value: mainAxisAlignment,
+                      items: const [
+                        DropdownMenuItem(
+                          value: MainAxisAlignment.start,
+                          child: Text('Start'),
+                        ),
+                        DropdownMenuItem(
+                          value: MainAxisAlignment.center,
+                          child: Text('Center'),
+                        ),
+                        DropdownMenuItem(
+                          value: MainAxisAlignment.end,
+                          child: Text('End'),
+                        ),
+                      ],
+                      onChanged: (value) => setState(
+                        () => mainAxisAlignment = value!,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ],
           ),

--- a/example/lib/screens/shrink_and_flex/shrink_and_flex_example_screen.dart
+++ b/example/lib/screens/shrink_and_flex/shrink_and_flex_example_screen.dart
@@ -51,9 +51,12 @@ class _ShrinkAndFlexExampleScreenState
                 ),
                 ResizableChild(
                   size: const ResizableSize.shrink(),
-                  child: ColoredBox(
-                    color: Theme.of(context).colorScheme.tertiaryContainer,
-                    child: const SizeLabel(),
+                  child: SizedBox(
+                    width: 100,
+                    child: ColoredBox(
+                      color: Theme.of(context).colorScheme.tertiaryContainer,
+                      child: const SizeLabel(),
+                    ),
                   ),
                 ),
               ],

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  decimal:
+    dependency: transitive
+    description:
+      name: decimal
+      sha256: da8f65df568345f2738cc8b0de74971c86d2d93ce5fc8c4ec094f6b7c5d48eb5
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -111,6 +119,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "99f282cb0e02edcbbf8c6b3bbc7c90b65635156c412e58f3975a7e55284ce685"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -199,6 +215,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/src/extensions/double_ext.dart
+++ b/lib/src/extensions/double_ext.dart
@@ -1,5 +1,0 @@
-import 'package:decimal/decimal.dart';
-
-extension DoubleExtensions on double {
-  Decimal toDecimal() => Decimal.parse(toString());
-}

--- a/lib/src/extensions/double_ext.dart
+++ b/lib/src/extensions/double_ext.dart
@@ -1,0 +1,5 @@
+import 'package:decimal/decimal.dart';
+
+extension DoubleExtensions on double {
+  Decimal toDecimal() => Decimal.parse(toString());
+}

--- a/lib/src/extensions/iterable_ext.dart
+++ b/lib/src/extensions/iterable_ext.dart
@@ -1,16 +1,7 @@
-extension IterableNumExtensions on Iterable<num> {
-  num sum() => fold(0, (sum, current) => sum + current);
-}
-
 extension IterableExtensions<T> on Iterable<T> {
   int nullCount() => where((item) => item == null).length;
 
   int count(bool Function(T) test) => where(test).length;
-
-  num sum(num Function(T) extractor) => fold(
-        0.0,
-        (sum, current) => sum + extractor(current),
-      );
 
   Iterable<T> evenIndices() => [
         for (var i = 0; i < length; i++) ...[

--- a/lib/src/extensions/iterable_ext.dart
+++ b/lib/src/extensions/iterable_ext.dart
@@ -10,4 +10,12 @@ extension IterableExtensions<T> on Iterable<T> {
           ],
         ],
       ];
+
+  Iterable<int> indicesWhere(bool Function(T) test) => [
+        for (var i = 0; i < length; i++) ...[
+          if (test(elementAt(i))) ...[
+            i,
+          ],
+        ],
+      ];
 }

--- a/lib/src/extensions/num_ext.dart
+++ b/lib/src/extensions/num_ext.dart
@@ -1,0 +1,13 @@
+import 'package:decimal/decimal.dart';
+
+extension DoubleExtensions on double {
+  Decimal toDecimal() => Decimal.parse(toString());
+}
+
+extension LisDoubleExtensions on Iterable<double> {
+  double sum() => fold(0.0, (sum, curr) => sum + curr);
+}
+
+extension ListIntExtensions on Iterable<int> {
+  double sum() => fold(0, (sum, curr) => sum + curr);
+}

--- a/lib/src/extensions/num_ext.dart
+++ b/lib/src/extensions/num_ext.dart
@@ -9,5 +9,5 @@ extension LisDoubleExtensions on Iterable<double> {
 }
 
 extension ListIntExtensions on Iterable<int> {
-  double sum() => fold(0, (sum, curr) => sum + curr);
+  int sum() => fold(0, (sum, curr) => sum + curr);
 }

--- a/lib/src/extensions/num_ext.dart
+++ b/lib/src/extensions/num_ext.dart
@@ -4,7 +4,7 @@ extension DoubleExtensions on double {
   Decimal toDecimal() => Decimal.parse(toString());
 }
 
-extension LisDoubleExtensions on Iterable<double> {
+extension ListDoubleExtensions on Iterable<double> {
   double sum() => fold(0.0, (sum, curr) => sum + curr);
 }
 

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -142,9 +142,9 @@ class ResizableLayoutRenderObject extends RenderBox
       final child = children[i];
       final size = sizes[i ~/ 2];
       final constraints = switch (size) {
-        ResizableSizeExpand() => layoutDirection.updateConstraints(
-            expandSizes[i ~/ 2]!,
+        ResizableSizeExpand() => layoutDirection.copyConstraintsWith(
             this.constraints,
+            expandSizes[i ~/ 2]!,
           ),
         _ => _getChildConstraints(
             size: size,

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -182,7 +182,8 @@ class ResizableLayoutRenderObject extends RenderBox
     }
 
     final allocatedSpace = Map<int, Decimal>.fromIterable(
-      expandIndices.map((index) => MapEntry(index, Decimal.zero)),
+      expandIndices,
+      value: (_) => Decimal.zero,
     );
 
     var remainingFlex = _getFlexCount().toDecimal();

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -299,10 +299,7 @@ class ResizableLayoutRenderObject extends RenderBox
   }
 
   int _getFlexCount() {
-    return sizes
-        .whereType<ResizableSizeExpand>()
-        .map((s) => s.flex)
-        .fold(0, (sum, curr) => sum + curr);
+    return sizes.whereType<ResizableSizeExpand>().map((s) => s.flex).sum();
   }
 
   BoxConstraints _getChildConstraints({

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -3,8 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
-import 'package:flutter_resizable_container/src/extensions/double_ext.dart';
-import 'package:flutter_resizable_container/src/extensions/iterable_ext.dart';
+import 'package:flutter_resizable_container/src/extensions/num_ext.dart';
 import 'package:flutter_resizable_container/src/layout/resizable_layout_direction.dart';
 import 'package:flutter_resizable_container/src/resizable_size.dart';
 
@@ -271,7 +270,7 @@ class ResizableLayoutRenderObject extends RenderBox
     return resizableChildren
         .take(resizableChildren.length - 1)
         .map((child) => child.divider.thickness + child.divider.padding)
-        .sum((x) => x)
+        .sum()
         .toDouble();
   }
 

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -202,7 +202,7 @@ class ResizableLayoutRenderObject extends RenderBox
 
         if (size is ResizableSizeExpand) {
           final flex = size.flex.toDecimal();
-          final currentValue = (allocatedSpace[index] ?? Decimal.zero);
+          final currentValue = allocatedSpace[index] ?? Decimal.zero;
           final targetDelta = targetDeltaPerFlex * flex;
           final targetSize = (currentValue + targetDelta).toDouble();
           final clampedValue = _clamp(targetSize, size).toDecimal();

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -174,17 +174,16 @@ class ResizableLayoutRenderObject extends RenderBox
 
   Map<int, Decimal> _getExpandSizes(double availableSpace) {
     bool isExpand(ResizableSize size) => size is ResizableSizeExpand;
+
     var expandIndices = _sizes.indicesWhere(isExpand).toList();
 
     if (expandIndices.isEmpty) {
       return {};
     }
 
-    final allocatedSpace = <int, Decimal>{
-      for (final index in expandIndices) ...{
-        index: Decimal.zero,
-      },
-    };
+    final allocatedSpace = Map<int, Decimal>.fromIterable(
+      expandIndices.map((index) => MapEntry(index, Decimal.zero)),
+    );
 
     var remainingFlex = _getFlexCount().toDecimal();
     var remainingSpace = availableSpace.toDecimal();

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -134,7 +134,7 @@ class ResizableLayoutRenderObject extends RenderBox
       shrinkSpace,
       requiredRatioSpace,
       dividerSpace,
-    ].fold(0.0, (sum, curr) => sum + curr);
+    ].sum();
     final expandDimension = layoutDirection.getMaxConstraint(constraints);
     final expandSpace = expandDimension - takenSpace;
     final expandSizes = _getExpandSizes(expandSpace);
@@ -246,7 +246,7 @@ class ResizableLayoutRenderObject extends RenderBox
       ],
     ];
 
-    return pixels.fold(0.0, (sum, curr) => sum + curr);
+    return pixels.sum();
   }
 
   double _getShrinkSpace(List<RenderBox> children) {
@@ -259,7 +259,7 @@ class ResizableLayoutRenderObject extends RenderBox
           ),
         ]
       ],
-    ].fold(0.0, (sum, curr) => sum + curr);
+    ].sum();
   }
 
   double _getDividerSpace() {
@@ -296,7 +296,7 @@ class ResizableLayoutRenderObject extends RenderBox
       ],
     ];
 
-    return sizes.fold(0.0, (sum, curr) => sum + curr);
+    return sizes.sum();
   }
 
   int _getFlexCount() {

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -171,7 +171,7 @@ class ResizableLayoutRenderObject extends RenderBox
   }
 
   Map<int, double> _getExpandSizes(double availableSpace) {
-    final expandIndices = <int>[
+    var expandIndices = <int>[
       for (var i = 0; i < _sizes.length; i++) ...[
         if (_sizes[i] is ResizableSizeExpand) ...[
           i,
@@ -195,11 +195,11 @@ class ResizableLayoutRenderObject extends RenderBox
 
     do {
       final targetDeltaPerFlex = remainingSpace / remainingFlex;
+      final toRemove = <int>[];
 
       didChange = false;
 
-      for (var i = 0; i < expandIndices.length; i++) {
-        final index = expandIndices[i];
+      for (final index in expandIndices) {
         final size = _sizes[index];
 
         if (size is ResizableSizeExpand) {
@@ -215,10 +215,12 @@ class ResizableLayoutRenderObject extends RenderBox
             didChange = true;
           } else {
             remainingFlex -= size.flex;
-            expandIndices.removeAt(i);
+            toRemove.add(index);
           }
         }
       }
+
+      expandIndices.removeWhere(toRemove.contains);
     } while (remainingSpace != 0 || didChange);
 
     return allocatedSpace;

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -203,12 +203,14 @@ class ResizableLayoutRenderObject extends RenderBox
         final size = _sizes[index];
 
         if (size is ResizableSizeExpand) {
+          final currentValue = allocatedSpace[index] ?? 0.0;
           final targetDelta = targetDeltaPerFlex * size.flex;
-          final targetSize = allocatedSpace[index]! + targetDelta;
+          final targetSize = currentValue + targetDelta;
           final clampedValue = _clamp(targetSize, size);
 
-          if (clampedValue != allocatedSpace[index]) {
-            remainingSpace -= clampedValue - allocatedSpace[index]!;
+          if (clampedValue != currentValue) {
+            final difference = clampedValue - currentValue;
+            remainingSpace -= difference;
             allocatedSpace[index] = clampedValue;
             didChange = true;
           } else {

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
+import 'package:flutter_resizable_container/src/extensions/iterable_ext.dart';
 import 'package:flutter_resizable_container/src/extensions/num_ext.dart';
 import 'package:flutter_resizable_container/src/layout/resizable_layout_direction.dart';
 import 'package:flutter_resizable_container/src/resizable_size.dart';
@@ -172,13 +173,8 @@ class ResizableLayoutRenderObject extends RenderBox
   }
 
   Map<int, Decimal> _getExpandSizes(double availableSpace) {
-    var expandIndices = <int>[
-      for (var i = 0; i < _sizes.length; i++) ...[
-        if (_sizes[i] is ResizableSizeExpand) ...[
-          i,
-        ],
-      ],
-    ];
+    bool isExpand(ResizableSize size) => size is ResizableSizeExpand;
+    var expandIndices = _sizes.indicesWhere(isExpand).toList();
 
     if (expandIndices.isEmpty) {
       return {};

--- a/lib/src/layout/resizable_layout_direction.dart
+++ b/lib/src/layout/resizable_layout_direction.dart
@@ -15,7 +15,7 @@ sealed class ResizableLayoutDirection {
   Offset getOffset(double currentPosition);
   Size getSize(double value, BoxConstraints constraints);
   double getMinIntrinsicDimension(RenderBox child);
-  BoxConstraints updateConstraints(double value, BoxConstraints constraints);
+  BoxConstraints copyConstraintsWith(BoxConstraints constraints, double value);
 }
 
 @visibleForTesting
@@ -48,7 +48,7 @@ class ResizableHorizontalLayout extends ResizableLayoutDirection {
   }
 
   @override
-  BoxConstraints updateConstraints(double value, BoxConstraints constraints) {
+  BoxConstraints copyConstraintsWith(BoxConstraints constraints, double value) {
     return constraints.copyWith(minWidth: value, maxWidth: value);
   }
 }
@@ -83,7 +83,7 @@ class ResizableVerticalLayout extends ResizableLayoutDirection {
   }
 
   @override
-  BoxConstraints updateConstraints(double value, BoxConstraints constraints) {
+  BoxConstraints copyConstraintsWith(BoxConstraints constraints, double value) {
     return constraints.copyWith(minHeight: value, maxHeight: value);
   }
 }

--- a/lib/src/layout/resizable_layout_direction.dart
+++ b/lib/src/layout/resizable_layout_direction.dart
@@ -10,11 +10,12 @@ sealed class ResizableLayoutDirection {
     };
   }
 
-  double getMaxConstraintDimension(BoxConstraints constraints);
+  double getMaxConstraint(BoxConstraints constraints);
   double getSizeDimension(Size size);
   Offset getOffset(double currentPosition);
   Size getSize(double value, BoxConstraints constraints);
   double getMinIntrinsicDimension(RenderBox child);
+  BoxConstraints updateConstraints(double value, BoxConstraints constraints);
 }
 
 @visibleForTesting
@@ -22,7 +23,7 @@ class ResizableHorizontalLayout extends ResizableLayoutDirection {
   const ResizableHorizontalLayout() : super._();
 
   @override
-  double getMaxConstraintDimension(BoxConstraints constraints) {
+  double getMaxConstraint(BoxConstraints constraints) {
     return constraints.maxWidth;
   }
 
@@ -45,6 +46,11 @@ class ResizableHorizontalLayout extends ResizableLayoutDirection {
   double getMinIntrinsicDimension(RenderBox child) {
     return child.getMinIntrinsicWidth(double.infinity);
   }
+
+  @override
+  BoxConstraints updateConstraints(double value, BoxConstraints constraints) {
+    return constraints.copyWith(minWidth: value, maxWidth: value);
+  }
 }
 
 @visibleForTesting
@@ -52,7 +58,7 @@ class ResizableVerticalLayout extends ResizableLayoutDirection {
   const ResizableVerticalLayout() : super._();
 
   @override
-  double getMaxConstraintDimension(BoxConstraints constraints) {
+  double getMaxConstraint(BoxConstraints constraints) {
     return constraints.maxHeight;
   }
 
@@ -74,5 +80,10 @@ class ResizableVerticalLayout extends ResizableLayoutDirection {
   @override
   double getMinIntrinsicDimension(RenderBox child) {
     return child.getMinIntrinsicHeight(double.infinity);
+  }
+
+  @override
+  BoxConstraints updateConstraints(double value, BoxConstraints constraints) {
+    return constraints.copyWith(minHeight: value, maxHeight: value);
   }
 }

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 import 'package:flutter_resizable_container/src/extensions/box_constraints_ext.dart';
 import 'package:flutter_resizable_container/src/extensions/iterable_ext.dart';
+import 'package:flutter_resizable_container/src/extensions/num_ext.dart';
 import 'package:flutter_resizable_container/src/resizable_container_divider.dart';
 import 'package:flutter_resizable_container/src/resizable_controller.dart';
 import 'package:flutter_resizable_container/src/layout/resizable_layout.dart';
@@ -162,7 +163,7 @@ class _ResizableContainerState extends State<ResizableContainer> {
         .take(widget.children.length - 1)
         .map((child) => child.divider)
         .map((divider) => divider.thickness + divider.padding)
-        .sum((x) => x);
+        .sum();
 
     return totalSpace - dividerSpace;
   }

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -3,6 +3,7 @@ import "dart:math";
 
 import 'package:flutter/material.dart';
 import "package:flutter_resizable_container/flutter_resizable_container.dart";
+import "package:flutter_resizable_container/src/extensions/num_ext.dart";
 import "package:flutter_resizable_container/src/resizable_size.dart";
 
 /// A controller to provide a programmatic interface to a [ResizableContainer].
@@ -34,9 +35,8 @@ class ResizableController with ChangeNotifier {
       throw ArgumentError('Must contain a value for every child');
     }
 
-    final totalPixels = sizes
-        .whereType<ResizableSizePixels>()
-        .fold(0.0, (sum, curr) => sum + curr.pixels);
+    final totalPixels =
+        sizes.whereType<ResizableSizePixels>().map((size) => size.pixels).sum();
 
     if (totalPixels > _availableSpace) {
       throw ArgumentError(
@@ -44,9 +44,8 @@ class ResizableController with ChangeNotifier {
       );
     }
 
-    final totalRatio = sizes
-        .whereType<ResizableSizeRatio>()
-        .fold(0.0, (sum, curr) => sum + curr.ratio);
+    final totalRatio =
+        sizes.whereType<ResizableSizeRatio>().map((size) => size.ratio).sum();
 
     if (totalRatio > 1.0) {
       throw ArgumentError('Total ratio must be less than or equal to 1.0');
@@ -154,7 +153,7 @@ class ResizableController with ChangeNotifier {
 
   double _getMinimumNecessarySize() {
     final minimums = _sizes.map((size) => size.min ?? 0.0).toList();
-    return minimums.fold(0.0, (sum, curr) => sum + curr);
+    return minimums.sum();
   }
 
   List<double> _distributeDelta({
@@ -192,7 +191,7 @@ class ResizableController with ChangeNotifier {
       return changePerItem;
     }).toList();
 
-    final changesSum = changes.fold(0.0, (sum, curr) => sum + curr);
+    final changesSum = changes.sum();
     final remainingChange = delta - changesSum;
 
     if (remainingChange.abs() > 0) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  decimal: ^3.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/layout/resizable_layout_direction_test.dart
+++ b/test/layout/resizable_layout_direction_test.dart
@@ -24,7 +24,7 @@ void main() {
       test('getMaxConstraintDimension returns maxWidth from constraints', () {
         final constraints = BoxConstraints(maxWidth: 100, maxHeight: 200);
 
-        final result = layout.getMaxConstraintDimension(constraints);
+        final result = layout.getMaxConstraint(constraints);
 
         expect(result, 100);
       });
@@ -82,7 +82,7 @@ void main() {
       test('getMaxConstraintDimension returns maxHeight from constraints', () {
         final constraints = BoxConstraints(maxWidth: 100, maxHeight: 200);
 
-        final result = layout.getMaxConstraintDimension(constraints);
+        final result = layout.getMaxConstraint(constraints);
 
         expect(result, 200);
       });

--- a/test/layout/resizable_layout_direction_test.dart
+++ b/test/layout/resizable_layout_direction_test.dart
@@ -21,7 +21,7 @@ void main() {
     group(ResizableHorizontalLayout, () {
       final layout = ResizableHorizontalLayout();
 
-      test('getMaxConstraintDimension returns maxWidth from constraints', () {
+      test('getMaxConstraint returns maxWidth from constraints', () {
         final constraints = BoxConstraints(maxWidth: 100, maxHeight: 200);
 
         final result = layout.getMaxConstraint(constraints);
@@ -79,7 +79,7 @@ void main() {
     group(ResizableVerticalLayout, () {
       final layout = ResizableVerticalLayout();
 
-      test('getMaxConstraintDimension returns maxHeight from constraints', () {
+      test('getMaxConstraint returns maxHeight from constraints', () {
         final constraints = BoxConstraints(maxWidth: 100, maxHeight: 200);
 
         final result = layout.getMaxConstraint(constraints);

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -99,6 +99,96 @@ void main() {
         expect(boxCSize.width, equals(399.2));
       });
 
+      testWidgets('correctly sizes expands with min constraints',
+          (tester) async {
+        await tester.binding.setSurfaceSize(const Size(1000, 1000));
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: ResizableContainer(
+                direction: Axis.horizontal,
+                children: [
+                  ResizableChild(
+                    size: ResizableSize.pixels(500),
+                    child: SizedBox.expand(
+                      key: Key('BoxA'),
+                    ),
+                  ),
+                  ResizableChild(
+                    size: ResizableSize.expand(),
+                    child: SizedBox.expand(
+                      key: Key('BoxB'),
+                    ),
+                  ),
+                  ResizableChild(
+                    size: ResizableSize.expand(flex: 1, min: 300),
+                    child: SizedBox.expand(
+                      key: Key('BoxC'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        final boxASize = tester.getSize(find.byKey(const Key('BoxA')));
+        final boxBSize = tester.getSize(find.byKey(const Key('BoxB')));
+        final boxCSize = tester.getSize(find.byKey(const Key('BoxC')));
+
+        expect(boxASize.width, equals(500));
+        expect(boxBSize.width, equals(200));
+        expect(boxCSize.width, equals(300));
+      });
+
+      testWidgets('correctly sizes expands with max constraints',
+          (tester) async {
+        await tester.binding.setSurfaceSize(const Size(1000, 1000));
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: ResizableContainer(
+                direction: Axis.horizontal,
+                children: [
+                  ResizableChild(
+                    size: ResizableSize.pixels(500),
+                    child: SizedBox.expand(
+                      key: Key('BoxA'),
+                    ),
+                  ),
+                  ResizableChild(
+                    size: ResizableSize.expand(),
+                    child: SizedBox.expand(
+                      key: Key('BoxB'),
+                    ),
+                  ),
+                  ResizableChild(
+                    size: ResizableSize.expand(max: 100),
+                    child: SizedBox.expand(
+                      key: Key('BoxC'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        final boxASize = tester.getSize(find.byKey(const Key('BoxA')));
+        final boxBSize = tester.getSize(find.byKey(const Key('BoxB')));
+        final boxCSize = tester.getSize(find.byKey(const Key('BoxC')));
+
+        expect(boxASize.width, equals(500));
+        expect(boxBSize.width, equals(400));
+        expect(boxCSize.width, equals(100));
+      });
+
       testWidgets('correctly sizes shrinks', (tester) async {
         // total space = 1000px
         // divider space = 2 * 1px = 2px

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -140,7 +140,7 @@ void main() {
         final boxCSize = tester.getSize(find.byKey(const Key('BoxC')));
 
         expect(boxASize.width, equals(500));
-        expect(boxBSize.width, equals(200));
+        expect(boxBSize.width, equals(198)); // account for two 1px dividers
         expect(boxCSize.width, equals(300));
       });
 
@@ -185,7 +185,7 @@ void main() {
         final boxCSize = tester.getSize(find.byKey(const Key('BoxC')));
 
         expect(boxASize.width, equals(500));
-        expect(boxBSize.width, equals(400));
+        expect(boxBSize.width, equals(398)); // account for two 1px dividers
         expect(boxCSize.width, equals(100));
       });
 
@@ -1059,7 +1059,7 @@ void main() {
       group('with a shrink and pixel child', () {
         testWidgets('delta is distributed evenly', (tester) async {
           final controller = ResizableController();
-          await tester.binding.setSurfaceSize(const Size(502, 500));
+          await tester.binding.setSurfaceSize(const Size(500, 500));
           await tester.pumpWidget(
             MaterialApp(
               home: Scaffold(
@@ -1073,7 +1073,7 @@ void main() {
                       ),
                       size: ResizableSize.shrink(),
                       child: SizedBox(
-                        width: 200,
+                        width: 150,
                         key: Key('BoxA'),
                       ),
                     ),
@@ -1100,7 +1100,7 @@ void main() {
           final boxASize = tester.getSize(boxAFinder);
           final boxBSize = tester.getSize(boxBFinder);
 
-          expect(boxASize.width, moreOrLessEquals(200, epsilon: 2));
+          expect(boxASize.width, moreOrLessEquals(150, epsilon: 2));
           expect(boxBSize.width, moreOrLessEquals(300, epsilon: 2));
 
           await tester.binding.setSurfaceSize(const Size(600, 500));
@@ -1109,7 +1109,7 @@ void main() {
           final newBoxASize = tester.getSize(boxAFinder);
           final newBoxBSize = tester.getSize(boxBFinder);
 
-          expect(newBoxASize.width, moreOrLessEquals(250, epsilon: 2));
+          expect(newBoxASize.width, moreOrLessEquals(200, epsilon: 2));
           expect(newBoxBSize.width, moreOrLessEquals(350, epsilon: 2));
         });
       });

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -807,11 +807,11 @@ void main() {
 
       expect(
         tester.getSize(find.byKey(const Key('ChildA'))).width,
-        moreOrLessEquals((1000 - 2) * 2 / 3),
+        moreOrLessEquals((1000 - 2) * (2 / 3), epsilon: 1),
       );
       expect(
         tester.getSize(find.byKey(const Key('ChildB'))).width,
-        moreOrLessEquals((1000 - 2) * 1 / 3),
+        moreOrLessEquals((1000 - 2) * (1 / 3), epsilon: 1),
       );
 
       await tester.tap(find.byKey(const Key('ToggleSwitch')));


### PR DESCRIPTION
This fixes #78 by adjusting the allocation of "expandable space" if one or more expand children has a min/max bound that conflicts with the original space allocation.