### PR TITLE
fix: custom divider

### DIFF
--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
+  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: decimal
-      sha256: da8f65df568345f2738cc8b0de74971c86d2d93ce5fc8c4ec094f6b7c5d48eb5
+      sha256: "28239b8b929c1bd8618702e6dbc96e2618cf99770bbe9cb040d6cf56a11e4ec3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.1"
   fake_async:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -107,26 +107,26 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
   intl:
     dependency: transitive
     description:
       name: intl
-      sha256: "99f282cb0e02edcbbf8c6b3bbc7c90b65635156c412e58f3975a7e55284ce685"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.0"
+    version: "0.20.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -187,18 +187,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: b93d8b4d624b4ea19b0a5a208b2d6eff06004bc3ce74c06040b120eeadd00ce0
+      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "8.3.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: f49918f3433a3146047372f9d4f1f847511f2acd5cd030e1f44fe5a50036b70e
+      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.0"
   path:
     dependency: transitive
     description:
@@ -280,10 +280,10 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -304,18 +304,18 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.0"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4
+      sha256: daf97c9d80197ed7b619040e86c8ab9a9dad285e7671ee7390f9180cc828a51e
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.1"
+    version: "5.10.1"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -1,8 +1,9 @@
+import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 
 /// Controls the sizing parameters for the [child] Widget.
-class ResizableChild {
+class ResizableChild extends Equatable {
   /// Create a new instance of the [ResizableChild] class.
   const ResizableChild({
     required this.child,
@@ -40,16 +41,8 @@ class ResizableChild {
   final ResizableDivider divider;
 
   @override
-  String toString() =>
-      'ResizableChildData(size: $size, child: $child, divider: $divider)';
+  bool get stringify => true;
 
   @override
-  operator ==(Object other) =>
-      other is ResizableChild &&
-      other.size == size &&
-      other.divider == divider &&
-      other.child.runtimeType == child.runtimeType;
-
-  @override
-  int get hashCode => Object.hash(size, child, divider);
+  List<Object?> get props => [size, child.runtimeType, divider];
 }

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -1,12 +1,11 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 import 'package:flutter_resizable_container/src/extensions/box_constraints_ext.dart';
 import 'package:flutter_resizable_container/src/extensions/iterable_ext.dart';
 import 'package:flutter_resizable_container/src/extensions/num_ext.dart';
+import 'package:flutter_resizable_container/src/layout/resizable_layout.dart';
 import 'package:flutter_resizable_container/src/resizable_container_divider.dart';
 import 'package:flutter_resizable_container/src/resizable_controller.dart';
-import 'package:flutter_resizable_container/src/layout/resizable_layout.dart';
 
 /// A container that holds multiple child [Widget]s that can be resized.
 ///
@@ -52,7 +51,8 @@ class _ResizableContainerState extends State<ResizableContainer> {
 
   @override
   void didUpdateWidget(covariant ResizableContainer oldWidget) {
-    final didChildrenChange = !listEquals(oldWidget.children, widget.children);
+    final didChildrenChange =
+        oldWidget.children.length != widget.children.length;
     final didDirectionChange = oldWidget.direction != widget.direction;
 
     if (didChildrenChange) {

--- a/lib/src/resizable_divider.dart
+++ b/lib/src/resizable_divider.dart
@@ -1,7 +1,8 @@
+import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/src/resizable_size.dart';
 
-class ResizableDivider {
+class ResizableDivider extends Equatable {
   const ResizableDivider({
     this.thickness = 1.0,
     this.length = const ResizableSize.expand(),
@@ -19,6 +20,9 @@ class ResizableDivider {
           length is! ResizableSizeShrink,
           'length does not support the "shrink" size',
         );
+
+  @override
+  bool get stringify => true;
 
   /// The thickness of the line drawn within the divider.
   ///
@@ -73,52 +77,17 @@ class ResizableDivider {
   final MouseCursor? cursor;
 
   @override
-  String toString() {
-    return 'ResizableDividerData('
-        'thickness: $thickness, '
-        'length: $length, '
-        'padding: $padding, '
-        'color: $color, '
-        'onHoverEnter: $onHoverEnter, '
-        'onHoverExit: $onHoverExit, '
-        'onTapDown: $onTapDown, '
-        'onTapUp: $onTapUp, '
-        'cursor: $cursor, '
-        'mainAxisAlignment: $mainAxisAlignment, '
-        'crossAxisAlignment: $crossAxisAlignment'
-        ')';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is ResizableDivider &&
-        other.thickness == thickness &&
-        other.length == length &&
-        other.padding == padding &&
-        other.color == color &&
-        other.onHoverEnter == onHoverEnter &&
-        other.onHoverExit == onHoverExit &&
-        other.onTapDown == onTapDown &&
-        other.onTapUp == onTapUp &&
-        other.cursor == cursor &&
-        other.mainAxisAlignment == mainAxisAlignment &&
-        other.crossAxisAlignment == crossAxisAlignment;
-  }
-
-  @override
-  int get hashCode {
-    return thickness.hashCode ^
-        length.hashCode ^
-        padding.hashCode ^
-        color.hashCode ^
-        onHoverEnter.hashCode ^
-        onHoverExit.hashCode ^
-        onTapDown.hashCode ^
-        onTapUp.hashCode ^
-        cursor.hashCode ^
-        mainAxisAlignment.hashCode ^
-        crossAxisAlignment.hashCode;
-  }
+  List<Object?> get props => [
+        thickness,
+        length,
+        padding,
+        color,
+        onHoverEnter,
+        onHoverExit,
+        onTapDown,
+        onTapUp,
+        cursor,
+        mainAxisAlignment,
+        crossAxisAlignment,
+      ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   decimal: ^3.1.0
+  equatable: ^2.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR resolves #86 by fixing a bug where the controller was re-settting the children anytime a divider changed, e.g. when an `onHover` triggered a `setState` that updated the divider's color.

Instead of using a deep-equality check on the `didUpdateWidget` hook, we're now just checking whether the length of the list of children changed. If this is not adequate, we may have to explore some different options in a future issue/PR.