### PR TITLE
feat: cascade negative deltas

### DIFF
--- a/example/lib/file_asset_paths.dart
+++ b/example/lib/file_asset_paths.dart
@@ -19,7 +19,11 @@ enum FileAssetPaths {
   ),
   shrinkAndFlexScreen(
     'lib/screens/shrink_and_flex/shrink_and_flex_example_screen.dart',
-  );
+  ),
+  cascadingDeltaScreen(
+    'lib/screens/cascading_delta/cascading_delta_screen.dart',
+  ),
+  ;
 
   const FileAssetPaths(this.path);
   final String path;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/screens/basic/basic_example_screen.dart';
+import 'package:example/screens/cascading_delta/cascading_delta_screen.dart';
 import 'package:example/screens/controller_listen/controller_listen_example_screen.dart';
 import 'package:example/screens/controller_set_sizes/controller_set_sizes_example_screen.dart';
 import 'package:example/screens/divider/custom_divider_example_screen.dart';
@@ -31,6 +32,7 @@ class ExampleApp extends StatelessWidget {
         'shrink': (context) => const ShrinkAndFlexExampleScreen(),
         'future-builder-shrink': (context) =>
             const FutureBuilderShrinkExampleScreen(),
+        'cascading-delta': (context) => const CascadingDeltaScreen(),
       },
     );
   }

--- a/example/lib/screens/cascading_delta/cascading_delta_help_dialog.dart
+++ b/example/lib/screens/cascading_delta/cascading_delta_help_dialog.dart
@@ -1,0 +1,71 @@
+import 'package:example/widgets/help_dialog.dart';
+import 'package:flutter/material.dart';
+
+class CascadingDeltaHelpDialog extends StatelessWidget {
+  const CascadingDeltaHelpDialog._({super.key});
+
+  static void show({
+    required BuildContext context,
+  }) {
+    HelpDialog.show(
+      context: context,
+      child: const CascadingDeltaHelpDialog._(
+        key: Key('CascadingDeltaHelpDialog'),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const HelpDialog(
+      title: 'About this example',
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'In this example, there are four children, each with a minimum width of 50 pixels.',
+          ),
+          SizedBox(height: 12),
+          Text.rich(TextSpan(children: [
+            TextSpan(text: 'Use the '),
+            TextSpan(
+              text: 'Cascade',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            TextSpan(text: ' switch to enable/disable the '),
+            TextSpan(
+              text: 'cascadeNegativeDelta',
+              style: TextStyle(
+                fontFamily: 'Monospace',
+                color: Colors.blueGrey,
+              ),
+            ),
+            TextSpan(text: ' flag in the ResizableContainer.'),
+          ])),
+          SizedBox(height: 12),
+          Text.rich(TextSpan(children: [
+            TextSpan(text: 'With the switch '),
+            TextSpan(
+              text: 'enabled',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            TextSpan(
+              text:
+                  ', reducing the size of a child beyond its bound will "cascade" the change to its sibling(s).',
+            ),
+            TextSpan(text: ' With the switch '),
+            TextSpan(
+              text: 'disabled',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            TextSpan(
+              text:
+                  ', reducing the size of a child beyond its bound will have no effect (default behavior).',
+            ),
+          ])),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/screens/cascading_delta/cascading_delta_screen.dart
+++ b/example/lib/screens/cascading_delta/cascading_delta_screen.dart
@@ -1,4 +1,5 @@
 import 'package:example/file_asset_paths.dart';
+import 'package:example/screens/cascading_delta/cascading_delta_help_dialog.dart';
 import 'package:example/widgets/code_view_dialog.dart';
 import 'package:example/widgets/nav_drawer.dart';
 import 'package:example/widgets/size_label.dart';
@@ -17,8 +18,6 @@ class _CascadingDeltaScreenState extends State<CascadingDeltaScreen> {
 
   @override
   Widget build(BuildContext context) {
-    const size = ResizableSize.expand(min: 50);
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('Basic two-pane example'),
@@ -33,10 +32,10 @@ class _CascadingDeltaScreenState extends State<CascadingDeltaScreen> {
               ),
             ],
           ),
-          // IconButton(
-          //   icon: const Icon(Icons.help_center),
-          //   onPressed: () => BasicExampleHelpDialog.show(context: context),
-          // ),
+          IconButton(
+            icon: const Icon(Icons.help_center),
+            onPressed: () => CascadingDeltaHelpDialog.show(context: context),
+          ),
           IconButton(
             icon: const Icon(Icons.code),
             onPressed: () => CodeViewDialog.show(
@@ -52,28 +51,28 @@ class _CascadingDeltaScreenState extends State<CascadingDeltaScreen> {
         cascadeNegativeDelta: cascade,
         children: [
           ResizableChild(
-            size: size,
+            size: const ResizableSize.expand(min: 50),
             child: ColoredBox(
               color: Theme.of(context).colorScheme.primaryContainer,
               child: const SizeLabel(),
             ),
           ),
           ResizableChild(
-            size: size,
+            size: const ResizableSize.expand(min: 50),
             child: ColoredBox(
               color: Theme.of(context).colorScheme.secondaryContainer,
               child: const SizeLabel(),
             ),
           ),
           ResizableChild(
-            size: size,
+            size: const ResizableSize.expand(min: 50),
             child: ColoredBox(
               color: Theme.of(context).colorScheme.primaryContainer,
               child: const SizeLabel(),
             ),
           ),
           ResizableChild(
-            size: size,
+            size: const ResizableSize.expand(min: 50),
             child: ColoredBox(
               color: Theme.of(context).colorScheme.secondaryContainer,
               child: const SizeLabel(),

--- a/example/lib/screens/cascading_delta/cascading_delta_screen.dart
+++ b/example/lib/screens/cascading_delta/cascading_delta_screen.dart
@@ -1,0 +1,86 @@
+import 'package:example/file_asset_paths.dart';
+import 'package:example/widgets/code_view_dialog.dart';
+import 'package:example/widgets/nav_drawer.dart';
+import 'package:example/widgets/size_label.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_resizable_container/flutter_resizable_container.dart';
+
+class CascadingDeltaScreen extends StatefulWidget {
+  const CascadingDeltaScreen({super.key});
+
+  @override
+  State<CascadingDeltaScreen> createState() => _CascadingDeltaScreenState();
+}
+
+class _CascadingDeltaScreenState extends State<CascadingDeltaScreen> {
+  var cascade = false;
+
+  @override
+  Widget build(BuildContext context) {
+    const size = ResizableSize.expand(min: 50);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Basic two-pane example'),
+        actions: [
+          Row(
+            children: [
+              const Text('Cascade'),
+              const SizedBox(width: 8),
+              Switch(
+                value: cascade,
+                onChanged: (cascade) => setState(() => this.cascade = cascade),
+              ),
+            ],
+          ),
+          // IconButton(
+          //   icon: const Icon(Icons.help_center),
+          //   onPressed: () => BasicExampleHelpDialog.show(context: context),
+          // ),
+          IconButton(
+            icon: const Icon(Icons.code),
+            onPressed: () => CodeViewDialog.show(
+              context: context,
+              filePath: FileAssetPaths.cascadingDeltaScreen,
+            ),
+          ),
+        ],
+      ),
+      drawer: const NavDrawer(),
+      body: ResizableContainer(
+        direction: Axis.horizontal,
+        cascadeNegativeDelta: cascade,
+        children: [
+          ResizableChild(
+            size: size,
+            child: ColoredBox(
+              color: Theme.of(context).colorScheme.primaryContainer,
+              child: const SizeLabel(),
+            ),
+          ),
+          ResizableChild(
+            size: size,
+            child: ColoredBox(
+              color: Theme.of(context).colorScheme.secondaryContainer,
+              child: const SizeLabel(),
+            ),
+          ),
+          ResizableChild(
+            size: size,
+            child: ColoredBox(
+              color: Theme.of(context).colorScheme.primaryContainer,
+              child: const SizeLabel(),
+            ),
+          ),
+          ResizableChild(
+            size: size,
+            child: ColoredBox(
+              color: Theme.of(context).colorScheme.secondaryContainer,
+              child: const SizeLabel(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/screens/cascading_delta/cascading_delta_screen.dart
+++ b/example/lib/screens/cascading_delta/cascading_delta_screen.dart
@@ -20,7 +20,7 @@ class _CascadingDeltaScreenState extends State<CascadingDeltaScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Basic two-pane example'),
+        title: const Text('Cascading delta example'),
         actions: [
           Row(
             children: [

--- a/example/lib/widgets/nav_drawer.dart
+++ b/example/lib/widgets/nav_drawer.dart
@@ -46,6 +46,11 @@ class NavDrawer extends StatelessWidget {
             onTap: () => Navigator.of(context)
                 .pushReplacementNamed('future-builder-shrink'),
           ),
+          ListTile(
+            title: const Text('Cascading Delta Example'),
+            onTap: () =>
+                Navigator.of(context).pushReplacementNamed('cascading-delta'),
+          ),
           const SizedBox(height: 15),
           const NavSectionHeader(title: 'Controller Examples'),
           ListTile(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -320,10 +320,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: dc6ecaa00a7c708e5b4d10ee7bec8c270e9276dfcab1783f57e9962d7884305f
+      sha256: daf97c9d80197ed7b619040e86c8ab9a9dad285e7671ee7390f9180cc828a51e
       url: "https://pub.dev"
     source: hosted
-    version: "5.12.0"
+    version: "5.10.1"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.22.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -70,6 +70,7 @@ flutter:
     - lib/screens/pixels/pixels_example_screen.dart
     - lib/screens/ratio/ratio_example_screen.dart
     - lib/screens/shrink_and_flex/shrink_and_flex_example_screen.dart
+    - lib/screens/cascading_delta/cascading_delta_screen.dart
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -15,8 +15,6 @@ import 'package:flutter_resizable_container/src/resizable_controller.dart';
 class ResizableContainer extends StatefulWidget {
   /// Creates a new [ResizableContainer] with the given [direction] and list
   /// of [children] Widgets.
-  ///
-  /// The sum of the [children]'s starting ratios must be equal to 1.0.
   const ResizableContainer({
     super.key,
     required this.children,
@@ -25,7 +23,7 @@ class ResizableContainer extends StatefulWidget {
     this.cascadeNegativeDelta = false,
   });
 
-  /// A list of resizable [ResizableChild] containing the child [Widget]s and
+  /// A list of [ResizableChild] containing the child [Widget]s and
   /// their sizing configuration.
   final List<ResizableChild> children;
 
@@ -62,17 +60,16 @@ class _ResizableContainerState extends State<ResizableContainer> {
     final directionChanged = oldWidget.direction != widget.direction;
     final cascadeChanged =
         oldWidget.cascadeNegativeDelta != widget.cascadeNegativeDelta;
-    final hasChanges = childrenChanged || directionChanged || cascadeChanged;
 
-    if (hasChanges) {
-      if (childrenChanged) {
-        controller.setChildren(widget.children);
-      }
+    if (childrenChanged) {
+      controller.setChildren(widget.children);
+    }
 
-      if (cascadeChanged) {
-        manager.setCascadeNegativeDelta(widget.cascadeNegativeDelta);
-      }
+    if (cascadeChanged) {
+      manager.setCascadeNegativeDelta(widget.cascadeNegativeDelta);
+    }
 
+    if (childrenChanged || directionChanged) {
       manager.setNeedsLayout();
     }
 

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -22,6 +22,7 @@ class ResizableContainer extends StatefulWidget {
     required this.children,
     required this.direction,
     this.controller,
+    this.cascadeNegativeDelta = false,
   });
 
   /// A list of resizable [ResizableChild] containing the child [Widget]s and
@@ -33,6 +34,10 @@ class ResizableContainer extends StatefulWidget {
 
   /// The direction along which the child widgets will be laid and resized.
   final Axis direction;
+
+  /// When enabled, reducing the size of a child beyond its lower bound will reduce the
+  /// size of its sibling(s). Defaults to `false`.
+  final bool cascadeNegativeDelta;
 
   @override
   State<ResizableContainer> createState() => _ResizableContainerState();
@@ -48,17 +53,24 @@ class _ResizableContainerState extends State<ResizableContainer> {
     super.initState();
 
     manager.initChildren(widget.children);
+    manager.setCascadeNegativeDelta(widget.cascadeNegativeDelta);
   }
 
   @override
   void didUpdateWidget(covariant ResizableContainer oldWidget) {
     final childrenChanged = !listEquals(oldWidget.children, widget.children);
     final directionChanged = oldWidget.direction != widget.direction;
-    final hasChanges = childrenChanged || directionChanged;
+    final cascadeChanged =
+        oldWidget.cascadeNegativeDelta != widget.cascadeNegativeDelta;
+    final hasChanges = childrenChanged || directionChanged || cascadeChanged;
 
     if (hasChanges) {
       if (childrenChanged) {
         controller.setChildren(widget.children);
+      }
+
+      if (cascadeChanged) {
+        manager.setCascadeNegativeDelta(widget.cascadeNegativeDelta);
       }
 
       manager.setNeedsLayout();

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -74,7 +74,7 @@ class ResizableController with ChangeNotifier {
         ? _getAdjustedReducingDelta(index: index, delta: delta)
         : _getAdjustedIncreasingDelta(index: index, delta: delta);
 
-    if (adjustedDelta == 0.0 && _cascadeNegativeDelta) {
+    if (adjustedDelta != delta && _cascadeNegativeDelta) {
       // if the current delta cannot be applied AND cascading is enabled
       if (delta < 0) {
         // and the divider is being dragged to the left

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -84,6 +84,10 @@ class ResizableController with ChangeNotifier {
 
         // apply the distribution outward from the selected index
         for (var i = 0; i < changes.length; i++) {
+          if (index - i - 1 < 0) {
+            continue;
+          }
+
           _pixels[index - i - 1] += changes[i];
         }
 
@@ -98,6 +102,10 @@ class ResizableController with ChangeNotifier {
 
         // apply the distribution outward from the selected index
         for (var i = 0; i < changes.length; i++) {
+          if (index + i + 1 >= _pixels.length) {
+            continue;
+          }
+
           _pixels[index + i + 1] += changes[i];
         }
 

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -1307,6 +1307,69 @@ void main() {
         expect(newBoxBSize.height, moreOrLessEquals(0, epsilon: 2));
       });
     });
+
+    group('when cascading is enabled', () {
+      testWidgets('negative deltas are applied to siblings', (tester) async {
+        await tester.binding.setSurfaceSize(const Size(303, 500));
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StatefulBuilder(
+              builder: (context, setState) {
+                return Scaffold(
+                  body: ResizableContainer(
+                    cascadeNegativeDelta: true,
+                    direction: Axis.horizontal,
+                    children: const [
+                      ResizableChild(
+                        size: ResizableSize.expand(),
+                        divider: ResizableDivider(
+                          thickness: 2,
+                        ),
+                        child: SizedBox.expand(
+                          key: Key('BoxA'),
+                        ),
+                      ),
+                      ResizableChild(
+                        size: ResizableSize.expand(min: 50),
+                        child: SizedBox.expand(
+                          key: Key('BoxB'),
+                        ),
+                      ),
+                      ResizableChild(
+                        size: ResizableSize.expand(min: 50),
+                        child: SizedBox.expand(
+                          key: Key('BoxC'),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        final handle = find.byType(ResizableContainerDivider).first;
+        expect(handle, isNotNull);
+
+        await tester.drag(handle, const Offset(kDragSlopDefault + 55, 0));
+        await tester.pump();
+
+        final boxAFinder = find.byKey(const Key('BoxA'));
+        final boxBFinder = find.byKey(const Key('BoxB'));
+        final boxCFinder = find.byKey(const Key('BoxC'));
+
+        final boxASize = tester.getSize(boxAFinder);
+        final boxBSize = tester.getSize(boxBFinder);
+        final boxCSize = tester.getSize(boxCFinder);
+
+        expect(boxASize.width, equals(155));
+        expect(boxBSize.width, equals(50));
+        expect(boxCSize.width, equals(95));
+      });
+    });
   });
 }
 


### PR DESCRIPTION
This PR adds a new feature that "cascades" negative deltas if the target child reaches its lower bound.

For example, if ChildA is resized down to its lower bound of 100px but the divider is dragged, this delta will be passed to its nearest sibling. If this sibling is at its lower bound, the delta will cascade to the _next_ sibling, and so on.

This resolves #84 