### PR TITLE
feat: drag events

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Any support is greatly appreciated!
 
 - `ResizableContainer`s are fully nestable and support LTR _and_ RTL layouts
 - Customize the look and feel of the divider(s) between children
-- Respond to user interactions with `onHoverEnter` and `onHoverExit` for web/desktop and `onTapDown` and `onTapUp` for mobile
+- Respond to user interactions with the `onDragStart`, `onDragEnd`, `onHoverEnter` (web/desktop), `onHoverExit` (web/desktop), `onTapDown` (mobile), and `onTapUp` (mobile)
 - Programmatically set the sizes of the children through a `ResizableController`
 - Respond to changes in the sizes of the resizable children by listening to the `ResizableController`
 
@@ -272,7 +272,7 @@ In this scenario, the first child would be given 2/3 of the total available spac
 
 Use the `ResizableDivider` class to customize the look and feel of the dividers between each of a container's children.
 
-You can customize the `thickness`, `length`, `crossAxisAlignment`, `mainAxisAlignment`, and `color` of the divider, as well as display a custom mouse cursor on hover and respond to `onHoverEnter` and `onHoverExit` (web) and `onTapDown` and `onTapUp` (mobile) events.
+You can customize the `thickness`, `length`, `crossAxisAlignment`, `mainAxisAlignment`, and `color` of the divider, as well as display a custom mouse cursor on hover and respond to `onDragStart`, `onDragEnd`, `onHoverEnter`, `onHoverExit`, `onTapDown`, and `onTapUp` events.
 
 ```dart
 divider: ResizableDivider(
@@ -281,6 +281,8 @@ divider: ResizableDivider(
     length: const ResizableSize.ratio(0.25),
     onHoverEnter: () => setState(() => hovered = true),
     onHoverExit: () => setState(() => hovered = false),
+    onDragStart: () => setState(() => dragging = true),
+    onDragEnd: () => setState(() => dragging = false),
     color: hovered ? Colors.blue : Colors.black,
     cursor: SystemMouseCursors.grab,
 ),

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -12,6 +12,7 @@ class ResizableChild extends Equatable {
     this.divider = const ResizableDivider(),
   });
 
+  /// The (optional) key for this child Widget's container in the list.
   final Key? key;
 
   /// The size of the corresponding widget. May use a ratio of the

--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -7,9 +7,12 @@ class ResizableChild extends Equatable {
   /// Create a new instance of the [ResizableChild] class.
   const ResizableChild({
     required this.child,
+    this.key,
     this.size = const ResizableSize.expand(),
     this.divider = const ResizableDivider(),
   });
+
+  final Key? key;
 
   /// The size of the corresponding widget. May use a ratio of the
   /// available space, an absolute size in logical pixels, or it can

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -125,6 +125,7 @@ class _ResizableContainerState extends State<ResizableContainer> {
                 children: [
                   for (var i = 0; i < widget.children.length; i++) ...[
                     Builder(
+                      key: widget.children[i].key,
                       builder: (context) {
                         final child = widget.children[i].child;
 

--- a/lib/src/resizable_container_divider.dart
+++ b/lib/src/resizable_container_divider.dart
@@ -133,6 +133,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   void _onVerticalDragStart(DragStartDetails _) {
     if (widget.direction == Axis.vertical) {
       setState(() => isDragging = true);
+      widget.config.onDragStart?.call();
     }
   }
 
@@ -145,6 +146,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   void _onVerticalDragEnd(DragEndDetails _) {
     if (widget.direction == Axis.vertical) {
       setState(() => isDragging = false);
+      widget.config.onDragEnd?.call();
 
       if (!isHovered) {
         widget.config.onHoverExit?.call();
@@ -155,6 +157,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   void _onHorizontalDragStart(DragStartDetails _) {
     if (widget.direction == Axis.horizontal) {
       setState(() => isDragging = true);
+      widget.config.onDragStart?.call();
     }
   }
 
@@ -176,6 +179,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   void _onHorizontalDragEnd(DragEndDetails _) {
     if (widget.direction == Axis.horizontal) {
       setState(() => isDragging = false);
+      widget.config.onDragEnd?.call();
 
       if (!isHovered) {
         widget.config.onHoverExit?.call();

--- a/lib/src/resizable_divider.dart
+++ b/lib/src/resizable_divider.dart
@@ -12,6 +12,8 @@ class ResizableDivider extends Equatable {
     this.onHoverExit,
     this.onTapDown,
     this.onTapUp,
+    this.onDragEnd,
+    this.onDragStart,
     this.cursor,
     this.mainAxisAlignment = MainAxisAlignment.center,
     this.crossAxisAlignment = CrossAxisAlignment.center,
@@ -72,6 +74,12 @@ class ResizableDivider extends Equatable {
 
   /// Triggers when the user's tap is released on this divider.
   final VoidCallback? onTapUp;
+
+  /// Triggers when the user begins dragging this divider.
+  final VoidCallback? onDragStart;
+
+  /// Triggers when the user stops dragging this divider.
+  final VoidCallback? onDragEnd;
 
   /// The cursor to display when hovering over this divider.
   final MouseCursor? cursor;

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -1234,6 +1234,54 @@ void main() {
       expect(boxBSizeAfter.width, greaterThan(boxBSize.width));
     });
 
+    testWidgets('fires drag events', (tester) async {
+      var dragStart = false;
+      var dragEnd = false;
+
+      await tester.binding.setSurfaceSize(const Size(1000, 1000));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: ResizableContainer(
+                direction: Axis.horizontal,
+                children: [
+                  ResizableChild(
+                    divider: ResizableDivider(
+                      onDragStart: () => dragStart = true,
+                      onDragEnd: () => dragEnd = true,
+                    ),
+                    size: ResizableSize.expand(),
+                    child: SizedBox.expand(
+                      key: Key('BoxA'),
+                    ),
+                  ),
+                  ResizableChild(
+                    size: ResizableSize.expand(),
+                    child: SizedBox.expand(
+                      key: Key('BoxB'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final divider = find.byType(ResizableContainerDivider);
+      expect(divider, findsOneWidget);
+
+      await tester.drag(divider, Offset(1 + kDragSlopDefault, 0));
+      await tester.pump();
+
+      expect(dragStart, isTrue);
+      expect(dragEnd, isTrue);
+    });
+
     group('when changing direction', () {
       testWidgets('children are resized correctly', (tester) async {
         final controller = ResizableController();


### PR DESCRIPTION
This PR is a recreation of #55 with full credit to the author(s). I waited too long and it became cumbersome to update the PR branch with changes I made to main.

This adds an `onDragStart` and `onDragEnd` method to the `ResizableDivider` to allow users to hook into these events. It also adds an optional key to the `ResizableChild`.