### PR TITLE
feat: update controller and container to only use visible children

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -139,26 +139,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -280,10 +280,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -296,10 +296,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -325,5 +325,5 @@ packages:
     source: hosted
     version: "5.13.0"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -107,6 +107,8 @@ class _ResizableContainerState extends State<ResizableContainer> {
         return AnimatedBuilder(
           animation: controller,
           builder: (context, _) {
+            final visibleChildren = _getVisibleChildren();
+
             if (controller.needsLayout) {
               return ResizableLayout(
                 direction: widget.direction,
@@ -117,13 +119,13 @@ class _ResizableContainerState extends State<ResizableContainer> {
                   });
                 },
                 sizes: controller.sizes,
-                resizableChildren: widget.children,
+                resizableChildren: visibleChildren,
                 children: [
-                  for (var i = 0; i < widget.children.length; i++) ...[
-                    widget.children[i].child,
-                    if (i < widget.children.length - 1) ...[
+                  for (var i = 0; i < visibleChildren.length; i++) ...[
+                    visibleChildren[i].child,
+                    if (i < visibleChildren.length - 1) ...[
                       ResizableContainerDivider.placeholder(
-                        config: widget.children[i].divider,
+                        config: visibleChildren[i].divider,
                         direction: widget.direction,
                       ),
                     ],
@@ -135,11 +137,11 @@ class _ResizableContainerState extends State<ResizableContainer> {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 direction: widget.direction,
                 children: [
-                  for (var i = 0; i < widget.children.length; i++) ...[
+                  for (var i = 0; i < visibleChildren.length; i++) ...[
                     Builder(
-                      key: widget.children[i].key,
+                      key: visibleChildren[i].key,
                       builder: (context) {
-                        final child = widget.children[i].child;
+                        final child = visibleChildren[i].child;
 
                         final height = _getChildSize(
                           index: i,
@@ -160,9 +162,9 @@ class _ResizableContainerState extends State<ResizableContainer> {
                         );
                       },
                     ),
-                    if (i < widget.children.length - 1) ...[
+                    if (i < visibleChildren.length - 1) ...[
                       ResizableContainerDivider(
-                        config: widget.children[i].divider,
+                        config: visibleChildren[i].divider,
                         direction: widget.direction,
                         onResizeUpdate: (delta) => manager.adjustChildSize(
                           index: i,
@@ -180,10 +182,21 @@ class _ResizableContainerState extends State<ResizableContainer> {
     );
   }
 
+  List<ResizableChild> _getVisibleChildren() {
+    return [
+      for (var i = 0; i < widget.children.length; i++) ...[
+        if (controller.isVisible(i)) ...[
+          widget.children[i],
+        ],
+      ],
+    ];
+  }
+
   double _getAvailableSpace(BoxConstraints constraints) {
+    final visibleChildren = _getVisibleChildren();
     final totalSpace = constraints.maxForDirection(widget.direction);
-    final dividerSpace = widget.children
-        .take(widget.children.length - 1)
+    final dividerSpace = visibleChildren
+        .take(visibleChildren.length - 1)
         .map((child) => child.divider)
         .map((divider) => divider.thickness + divider.padding)
         .sum();

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -92,21 +92,25 @@ class ResizableController with ChangeNotifier {
       if (delta < 0) {
         // and the divider is being dragged to the left
 
-        // distribute the delta amongst the leftward siblings
+        // distribute the delta amongst the visible leftward siblings
         final changes = _distributeDeltaLeft(index: index, delta: delta);
 
         // apply the distribution outward from the selected index
         for (var i = 0; i < changes.length; i++) {
-          if (index - i - 1 < 0) {
+          var siblingIndex = _visibleIndices[index - i - 1];
+
+          if (siblingIndex < 0) {
             continue;
           }
 
-          _pixels[index - i - 1] += changes[i];
+          // apply the change to the next visible leftward sibling
+          _pixels[siblingIndex] += changes[i];
         }
 
-        // adjust the width of the first sibling to the right by the
+        // adjust the width of the first visible sibling to the right by the
         // total amount removed from the leftward siblings
-        _pixels[index + 1] += changes.sum().abs();
+        var nextSiblingIndex = _visibleIndices[index + 1];
+        _pixels[nextSiblingIndex] += changes.sum().abs();
       } else {
         // and the divider is being dragged to the right
 
@@ -115,22 +119,26 @@ class ResizableController with ChangeNotifier {
 
         // apply the distribution outward from the selected index
         for (var i = 0; i < changes.length; i++) {
-          if (index + i + 1 >= _pixels.length) {
+          var siblingIndex = _visibleIndices[index + i + 1];
+
+          if (siblingIndex >= pixels.length) {
             continue;
           }
 
-          _pixels[index + i + 1] += changes[i];
+          // apply the change to the next visible rightward sibling
+          _pixels[siblingIndex] += changes[i];
         }
 
-        // adjust the width of the selected index by the total amount
-        // removed from the rightward siblings
-        _pixels[index] += changes.sum().abs();
+        // adjust the width of the first visible sibling to the left by the
+        // total amount removed from the rightward siblings
+        var previousSiblingIndex = _visibleIndices[index - 1];
+        _pixels[previousSiblingIndex] += changes.sum().abs();
       }
     } else {
       // otherwise, apply the adjusted delta to the selected index and its
       // immediate rightward sibling
-      _pixels[index] += adjustedDelta;
-      _pixels[index + 1] -= adjustedDelta;
+      _pixels[_visibleIndices[index]] += adjustedDelta;
+      _pixels[_visibleIndices[index + 1]] -= adjustedDelta;
     }
 
     notifyListeners();
@@ -148,6 +156,14 @@ class ResizableController with ChangeNotifier {
     _children = children;
     _sizes = children.map((child) => child.size).toList();
     _pixels = List.filled(children.length, 0);
+    _visibleIndices = [
+      for (var i = 0; i < children.length; i++) ...[
+        if (children[i].visible) ...[
+          i,
+        ],
+      ],
+    ];
+
     _needsLayout = true;
 
     if (notify) {
@@ -156,7 +172,23 @@ class ResizableController with ChangeNotifier {
   }
 
   void _setRenderedSizes(List<double> pixels) {
-    _pixels = pixels;
+    _pixels = [];
+
+    // set the pixels for the visible children
+    //
+    // if the child is visible, set its size to the corresponding pixel
+    // size and increment the pixel index
+    // if the child is not visible, set its size to 0.0
+    var pixelIndex = 0;
+    for (var i = 0; i < _children.length; i++) {
+      if (_visibleIndices.contains(i)) {
+        _pixels.add(pixels[pixelIndex]);
+        pixelIndex++;
+      } else {
+        _pixels.add(0.0);
+      }
+    }
+
     _needsLayout = false;
     notifyListeners();
   }
@@ -219,7 +251,7 @@ class ResizableController with ChangeNotifier {
   }
 
   double _getMinimumNecessarySize() {
-    final minimums = _sizes.map((size) => size.min ?? 0.0).toList();
+    final minimums = sizes.map((size) => size.min ?? 0.0).toList();
     return minimums.sum();
   }
 
@@ -227,15 +259,19 @@ class ResizableController with ChangeNotifier {
     required int index,
     required double delta,
   }) {
-    // get the indices of all rightward siblings
+    // get the indices of all visible rightward siblings
     final indices = [
-      for (var i = index + 1; i < _children.length; i++) i,
+      for (var i = index + 1; i < _children.length; i++) ...[
+        if (_visibleIndices.contains(i)) ...[
+          i,
+        ],
+      ],
     ];
 
     // calculate the allowable change for each sibling
     final allowableChanges = [
       for (final index in indices) ...[
-        _getAllowableChange(delta: -delta, index: index, sizes: _pixels),
+        _getAllowableChange(delta: -delta, index: index, sizes: pixels),
       ],
     ];
 
@@ -259,15 +295,19 @@ class ResizableController with ChangeNotifier {
     required int index,
     required double delta,
   }) {
-    // get the indices of all leftward siblings
+    // get the indices of all visible leftward siblings
     final indices = [
-      for (var i = 0; i < index; i++) i,
+      for (var i = 0; i < index; i++) ...[
+        if (_visibleIndices.contains(i)) ...[
+          i,
+        ],
+      ],
     ];
 
     // calculate the allowable change for each sibling
     final allowableChanges = [
       for (final index in indices) ...[
-        _getAllowableChange(delta: delta, index: index, sizes: _pixels),
+        _getAllowableChange(delta: delta, index: index, sizes: pixels),
       ],
     ];
 
@@ -291,7 +331,14 @@ class ResizableController with ChangeNotifier {
     required double delta,
     required List<double> sizes,
   }) {
-    final indices = List.generate(_children.length, (i) => i);
+    final indices = [
+      for (var i = 0; i < _children.length; i++) ...[
+        if (_visibleIndices.contains(i)) ...[
+          i,
+        ],
+      ],
+    ];
+
     final changeableIndices = _getChangeableIndices(delta < 0 ? -1 : 1, sizes);
 
     if (changeableIndices.isEmpty) {
@@ -351,7 +398,7 @@ class ResizableController with ChangeNotifier {
     final targetSize = sizes[index] + delta;
 
     if (delta < 0) {
-      final minimumSize = _sizes[index].min ?? 0;
+      final minimumSize = this.sizes[index].min ?? 0;
 
       if (targetSize <= minimumSize) {
         return minimumSize - sizes[index];
@@ -360,7 +407,7 @@ class ResizableController with ChangeNotifier {
       return delta;
     }
 
-    final maximumSize = _sizes[index].max ?? double.infinity;
+    final maximumSize = this.sizes[index].max ?? double.infinity;
 
     if (targetSize >= maximumSize) {
       return maximumSize - sizes[index];
@@ -370,12 +417,18 @@ class ResizableController with ChangeNotifier {
   }
 
   List<int> _getChangeableIndices(int direction, List<double> sizes) {
-    final indices = List.generate(_children.length, (i) => i);
     final List<int> changeableIndices = [];
+    final indices = [
+      for (var i = 0; i < _children.length; i++) ...[
+        if (_visibleIndices.contains(i)) ...[
+          i,
+        ],
+      ],
+    ];
 
     bool shouldAdd(index) {
-      final minSize = _sizes[index].min ?? 0.0;
-      final maxSize = _sizes[index].max ?? double.infinity;
+      final minSize = this.sizes[index].min ?? 0.0;
+      final maxSize = this.sizes[index].max ?? double.infinity;
 
       if (direction < 0 && sizes[index] > minSize) {
         return true;
@@ -387,7 +440,7 @@ class ResizableController with ChangeNotifier {
     }
 
     for (final index in indices) {
-      if (_children[index].size is! ResizableSizeExpand) {
+      if (this.sizes[index] is! ResizableSizeExpand) {
         continue;
       }
 
@@ -414,9 +467,9 @@ class ResizableController with ChangeNotifier {
     required double delta,
   }) {
     final currentSize = pixels[index];
-    final minCurrentSize = _sizes[index].min ?? 0;
+    final minCurrentSize = sizes[index].min ?? 0;
     final adjacentSize = pixels[index + 1];
-    final maxAdjacentSize = _sizes[index + 1].max ?? double.infinity;
+    final maxAdjacentSize = sizes[index + 1].max ?? double.infinity;
     final maxCurrentDelta = currentSize - minCurrentSize;
     final maxAdjacentDelta = maxAdjacentSize - adjacentSize;
     final maxDelta = min(maxCurrentDelta, maxAdjacentDelta);
@@ -433,9 +486,9 @@ class ResizableController with ChangeNotifier {
     required double delta,
   }) {
     final currentSize = pixels[index];
-    final maxCurrentSize = _sizes[index].max ?? double.infinity;
+    final maxCurrentSize = sizes[index].max ?? double.infinity;
     final adjacentSize = pixels[index + 1];
-    final minAdjacentSize = _sizes[index + 1].min ?? 0;
+    final minAdjacentSize = sizes[index + 1].min ?? 0;
     final maxAvailableSpace = min(maxCurrentSize, _availableSpace);
     final maxCurrentDelta = maxAvailableSpace - currentSize;
     final maxAdjacentDelta = adjacentSize - minAdjacentSize;

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -79,6 +79,8 @@ class ResizableController with ChangeNotifier {
     notifyListeners();
   }
 
+  bool isVisible(int index) => _visibleIndices.contains(index);
+
   void _adjustChildSize({
     required int index,
     required double delta,

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -10,6 +10,7 @@ import "package:flutter_resizable_container/src/resizable_size.dart";
 class ResizableController with ChangeNotifier {
   double _availableSpace = -1;
   List<double> _pixels = [];
+  List<int> _visibleIndices = const [];
   List<ResizableSize> _sizes = const [];
   List<ResizableChild> _children = const [];
   bool _needsLayout = false;
@@ -19,19 +20,31 @@ class ResizableController with ChangeNotifier {
   bool get needsLayout => _needsLayout;
 
   /// The physical size, in pixels, of each child.
-  UnmodifiableListView<double> get pixels => UnmodifiableListView(_pixels);
+  UnmodifiableListView<double> get pixels => UnmodifiableListView([
+        for (var i = 0; i < _children.length; i++) ...[
+          if (_visibleIndices.contains(i)) ...[
+            _pixels[i],
+          ],
+        ],
+      ]);
 
   /// The [ResizableSize] of each child.
-  UnmodifiableListView<ResizableSize> get sizes => UnmodifiableListView(_sizes);
+  UnmodifiableListView<ResizableSize> get sizes => UnmodifiableListView([
+        for (var i = 0; i < _children.length; i++) ...[
+          if (_visibleIndices.contains(i)) ...[
+            _sizes[i],
+          ],
+        ],
+      ]);
 
   /// A list of ratios (proportion of total available space taken) for each child.
-  UnmodifiableListView<double> get ratios {
-    return UnmodifiableListView([
-      for (final size in pixels) ...[
-        size / _availableSpace,
-      ],
-    ]);
-  }
+  UnmodifiableListView<double> get ratios => UnmodifiableListView([
+        for (var i = 0; i < _children.length; i++) ...[
+          if (_visibleIndices.contains(i)) ...[
+            _pixels[i] / _availableSpace,
+          ],
+        ],
+      ]);
 
   /// Update the [ResizableSize] used to control each child.
   ///

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -81,6 +81,8 @@ class ResizableController with ChangeNotifier {
 
   bool isVisible(int index) => _visibleIndices.contains(index);
 
+  int _getRawIndex(int visibleIndex) => _visibleIndices[visibleIndex];
+
   void _adjustChildSize({
     required int index,
     required double delta,
@@ -99,20 +101,19 @@ class ResizableController with ChangeNotifier {
 
         // apply the distribution outward from the selected index
         for (var i = 0; i < changes.length; i++) {
-          var siblingIndex = _visibleIndices[index - i - 1];
+          var siblingIndex = index - i - 1;
 
           if (siblingIndex < 0) {
             continue;
           }
 
           // apply the change to the next visible leftward sibling
-          _pixels[siblingIndex] += changes[i];
+          _pixels[_getRawIndex(siblingIndex)] += changes[i];
         }
 
         // adjust the width of the first visible sibling to the right by the
         // total amount removed from the leftward siblings
-        var nextSiblingIndex = _visibleIndices[index + 1];
-        _pixels[nextSiblingIndex] += changes.sum().abs();
+        _pixels[_getRawIndex(index + 1)] += changes.sum().abs();
       } else {
         // and the divider is being dragged to the right
 
@@ -121,26 +122,26 @@ class ResizableController with ChangeNotifier {
 
         // apply the distribution outward from the selected index
         for (var i = 0; i < changes.length; i++) {
-          var siblingIndex = _visibleIndices[index + i + 1];
+          final siblingIndex = index + i + 1;
 
           if (siblingIndex >= pixels.length) {
             continue;
           }
 
           // apply the change to the next visible rightward sibling
-          _pixels[siblingIndex] += changes[i];
+          _pixels[_getRawIndex(siblingIndex)] += changes[i];
         }
 
-        // adjust the width of the first visible sibling to the left by the
+        // adjust the width of the selected index by the
         // total amount removed from the rightward siblings
-        var previousSiblingIndex = _visibleIndices[index - 1];
-        _pixels[previousSiblingIndex] += changes.sum().abs();
+
+        _pixels[_getRawIndex(index)] += changes.sum().abs();
       }
     } else {
       // otherwise, apply the adjusted delta to the selected index and its
       // immediate rightward sibling
-      _pixels[_visibleIndices[index]] += adjustedDelta;
-      _pixels[_visibleIndices[index + 1]] -= adjustedDelta;
+      _pixels[_getRawIndex(index)] += adjustedDelta;
+      _pixels[_getRawIndex(index + 1)] -= adjustedDelta;
     }
 
     notifyListeners();
@@ -226,7 +227,7 @@ class ResizableController with ChangeNotifier {
     );
 
     for (var i = 0; i < sizes.length; i++) {
-      _pixels[i] += distributed[i];
+      _pixels[_getRawIndex(i)] += distributed[i];
     }
 
     _availableSpace = availableSpace;
@@ -262,13 +263,10 @@ class ResizableController with ChangeNotifier {
     required double delta,
   }) {
     // get the indices of all visible rightward siblings
-    final indices = [
-      for (var i = index + 1; i < _children.length; i++) ...[
-        if (_visibleIndices.contains(i)) ...[
-          i,
-        ],
-      ],
-    ];
+    final indices = List.generate(
+      _visibleIndices.length - index - 1,
+      (i) => index + i + 1,
+    );
 
     // calculate the allowable change for each sibling
     final allowableChanges = [
@@ -297,14 +295,8 @@ class ResizableController with ChangeNotifier {
     required int index,
     required double delta,
   }) {
-    // get the indices of all visible leftward siblings
-    final indices = [
-      for (var i = 0; i < index; i++) ...[
-        if (_visibleIndices.contains(i)) ...[
-          i,
-        ],
-      ],
-    ];
+    // get the indices of all leftward siblings
+    final indices = List.generate(index, (i) => i);
 
     // calculate the allowable change for each sibling
     final allowableChanges = [
@@ -333,14 +325,7 @@ class ResizableController with ChangeNotifier {
     required double delta,
     required List<double> sizes,
   }) {
-    final indices = [
-      for (var i = 0; i < _children.length; i++) ...[
-        if (_visibleIndices.contains(i)) ...[
-          i,
-        ],
-      ],
-    ];
-
+    final indices = List.generate(_visibleIndices.length, (i) => i);
     final changeableIndices = _getChangeableIndices(delta < 0 ? -1 : 1, sizes);
 
     if (changeableIndices.isEmpty) {
@@ -420,13 +405,7 @@ class ResizableController with ChangeNotifier {
 
   List<int> _getChangeableIndices(int direction, List<double> sizes) {
     final List<int> changeableIndices = [];
-    final indices = [
-      for (var i = 0; i < _children.length; i++) ...[
-        if (_visibleIndices.contains(i)) ...[
-          i,
-        ],
-      ],
-    ];
+    final indices = List.generate(_visibleIndices.length, (i) => i);
 
     bool shouldAdd(index) {
       final minSize = this.sizes[index].min ?? 0.0;

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -20,31 +20,19 @@ class ResizableController with ChangeNotifier {
   bool get needsLayout => _needsLayout;
 
   /// The physical size, in pixels, of each child.
-  UnmodifiableListView<double> get pixels => UnmodifiableListView([
-        for (var i = 0; i < _children.length; i++) ...[
-          if (_visibleIndices.contains(i)) ...[
-            _pixels[i],
-          ],
-        ],
-      ]);
+  UnmodifiableListView<double> get pixels => UnmodifiableListView(
+        _visibleIndices.map((i) => _pixels[i]),
+      );
 
   /// The [ResizableSize] of each child.
-  UnmodifiableListView<ResizableSize> get sizes => UnmodifiableListView([
-        for (var i = 0; i < _children.length; i++) ...[
-          if (_visibleIndices.contains(i)) ...[
-            _sizes[i],
-          ],
-        ],
-      ]);
+  UnmodifiableListView<ResizableSize> get sizes => UnmodifiableListView(
+        _visibleIndices.map((i) => _sizes[i]),
+      );
 
   /// A list of ratios (proportion of total available space taken) for each child.
-  UnmodifiableListView<double> get ratios => UnmodifiableListView([
-        for (var i = 0; i < _children.length; i++) ...[
-          if (_visibleIndices.contains(i)) ...[
-            _pixels[i] / _availableSpace,
-          ],
-        ],
-      ]);
+  UnmodifiableListView<double> get ratios => UnmodifiableListView(
+        _visibleIndices.map((i) => _pixels[i] / _availableSpace),
+      );
 
   /// Update the [ResizableSize] used to control each child.
   ///

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -113,7 +113,7 @@ class ResizableController with ChangeNotifier {
         for (var i = 0; i < changes.length; i++) {
           final siblingIndex = index + i + 1;
 
-          if (siblingIndex >= pixels.length) {
+          if (siblingIndex >= _visibleIndices.length) {
             continue;
           }
 

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -8,9 +8,10 @@ import "package:flutter_resizable_container/src/resizable_size.dart";
 
 /// A controller to provide a programmatic interface to a [ResizableContainer].
 class ResizableController with ChangeNotifier {
+  final _visibleIndices = SplayTreeSet<int>();
+
   double _availableSpace = -1;
   List<double> _pixels = [];
-  List<int> _visibleIndices = const [];
   List<ResizableSize> _sizes = const [];
   List<ResizableChild> _children = const [];
   bool _needsLayout = false;
@@ -69,7 +70,7 @@ class ResizableController with ChangeNotifier {
 
   bool isVisible(int index) => _visibleIndices.contains(index);
 
-  int _getRawIndex(int visibleIndex) => _visibleIndices[visibleIndex];
+  int _getRawIndex(int visibleIndex) => _visibleIndices.elementAt(visibleIndex);
 
   void _adjustChildSize({
     required int index,
@@ -147,13 +148,13 @@ class ResizableController with ChangeNotifier {
     _children = children;
     _sizes = children.map((child) => child.size).toList();
     _pixels = List.filled(children.length, 0);
-    _visibleIndices = [
-      for (var i = 0; i < children.length; i++) ...[
-        if (children[i].visible) ...[
-          i,
-        ],
-      ],
-    ];
+    _visibleIndices.clear();
+
+    for (var i = 0; i < children.length; i++) {
+      if (children[i].visible) {
+        _visibleIndices.add(i);
+      }
+    }
 
     _needsLayout = true;
 


### PR DESCRIPTION
Update the controller and container to only display and resize visible children.

No logic yet exists to hide any child, but this PR adds the logic necessary to support 
hiding children and allowing the visible children to be resized.

- **filter getters**
- **update controller to only use visible indices in calculations**
- **only use visible children in container**
- **refactor: update indices to map between visible/hidden children**
