### PR TITLE
feat: animate hide/show child transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- feat: animate hide/show transitions via `hideAnimation`. Pass a `ResizableHideAnimation` to `ResizableContainer.hideAnimation` to tween the affected child and its siblings between their current and target sizes when `ResizableController.hide` or `ResizableController.show` is called. Defaults to `null` (instant snap, unchanged behavior).
+
 ## 4.2.0
 
 - Added `cascadeNegativeDelta` flag to cascade changes through children that have reached their lower bound.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Unreleased
-
-- feat: animate hide/show transitions via `hideAnimation`. Pass a `ResizableHideAnimation` to `ResizableContainer.hideAnimation` to tween the affected child and its siblings between their current and target sizes when `ResizableController.hide` or `ResizableController.show` is called. Defaults to `null` (instant snap, unchanged behavior).
-
 ## 4.2.0
 
 - Added `cascadeNegativeDelta` flag to cascade changes through children that have reached their lower bound.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,29 @@ Calls to `setSizes` while a child is hidden store the new size and apply it
 the next time the child is shown; the child stays hidden until you call
 `show`.
 
+##### Animating hide/show
+
+By default, `hide`/`show` snap the affected child to its new size in a
+single frame. To tween the transition, pass a `ResizableHideAnimation` to
+the container's `hideAnimation` parameter:
+
+```dart
+ResizableContainer(
+  direction: Axis.horizontal,
+  controller: controller,
+  hideAnimation: const ResizableHideAnimation(
+    duration: Duration(milliseconds: 200),
+    curve: Curves.easeInOut,
+  ),
+  children: [ ... ],
+);
+```
+
+When non-null, the affected child and its siblings interpolate between
+their current rendered sizes and the new targets over the configured
+duration and curve. All other size transitions (divider drag, `setSizes`,
+available-space changes) remain instant.
+
 ### ResizableChild
 
 To add widgets to your container, you must provide a `List<ResizableChild>`, each of which contain the child `Widget`, an optional `ResizableDivider`, and an optional `ResizableSize`.

--- a/example/lib/screens/hide_show/hide_show_example_screen.dart
+++ b/example/lib/screens/hide_show/hide_show_example_screen.dart
@@ -18,6 +18,8 @@ class _HideShowExampleScreenState extends State<HideShowExampleScreen> {
 
   final controller = ResizableController();
 
+  bool _animate = true;
+
   @override
   void initState() {
     super.initState();
@@ -44,6 +46,15 @@ class _HideShowExampleScreenState extends State<HideShowExampleScreen> {
       appBar: AppBar(
         title: const Text('Hide / Show example'),
         actions: [
+          IconButton(
+            tooltip: _animate
+                ? 'Animated hide/show is on'
+                : 'Animated hide/show is off',
+            onPressed: () => setState(() => _animate = !_animate),
+            icon: Icon(
+              _animate ? Icons.animation : Icons.flash_on,
+            ),
+          ),
           IconButton(
             tooltip: leftHidden ? 'Show left panel' : 'Hide left panel',
             onPressed: () => controller.setHidden(_leftIndex, !leftHidden),
@@ -80,6 +91,7 @@ class _HideShowExampleScreenState extends State<HideShowExampleScreen> {
       body: ResizableContainer(
         controller: controller,
         direction: Axis.horizontal,
+        hideAnimation: _animate ? const ResizableHideAnimation() : null,
         children: [
           ResizableChild(
             size: const ResizableSize.pixels(240),

--- a/lib/flutter_resizable_container.dart
+++ b/lib/flutter_resizable_container.dart
@@ -4,4 +4,5 @@ export 'src/resizable_container.dart';
 export 'src/resizable_controller.dart' show ResizableController;
 export 'src/resizable_child.dart';
 export 'src/resizable_divider.dart';
+export 'src/resizable_hide_animation.dart';
 export 'src/resizable_size.dart' show ResizableSize;

--- a/lib/src/hide_animation_coordinator.dart
+++ b/lib/src/hide_animation_coordinator.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_resizable_container/src/resizable_hide_animation.dart';
+
+/// Where in the hide/show animation lifecycle the coordinator is.
+enum HideAnimationPhase {
+  /// No animation in flight. The widget should render from its own source of
+  /// truth (the controller's sizes).
+  idle,
+
+  /// A transition is starting: the from-snapshot has been captured, but the
+  /// target has not yet been measured. The widget should still render the
+  /// from-snapshot while a layout pass measures the target offstage.
+  capturing,
+
+  /// The animation is running. The widget should render
+  /// [HideAnimationCoordinator.currentSizes].
+  animating,
+}
+
+/// Owns the animation state for `ResizableContainer.hideAnimation`.
+///
+/// The coordinator tracks the from/to snapshots, drives the
+/// [AnimationController], and exposes the interpolated sizes the widget
+/// should render. The widget owns the rendering decisions; this class owns
+/// the math and lifecycle.
+class HideAnimationCoordinator {
+  HideAnimationCoordinator({
+    required TickerProvider vsync,
+    required VoidCallback onChanged,
+  })  : _vsync = vsync,
+        _onChanged = onChanged;
+
+  final TickerProvider _vsync;
+  final VoidCallback _onChanged;
+
+  AnimationController? _controller;
+  List<double>? _from;
+  List<double>? _to;
+  Curve _curve = Curves.linear;
+
+  HideAnimationPhase get phase {
+    if (_from == null) return HideAnimationPhase.idle;
+    if (_to == null) return HideAnimationPhase.capturing;
+    return HideAnimationPhase.animating;
+  }
+
+  /// The full alternating list of child + divider pixel sizes the widget
+  /// should render right now.
+  ///
+  /// Returns `null` in [HideAnimationPhase.idle], signaling the caller should
+  /// fall back to its own source of truth.
+  List<double>? get currentSizes {
+    final from = _from;
+    if (from == null) return null;
+
+    final to = _to;
+    if (to == null) return List.of(from);
+
+    final t = _curve.transform(_controller!.value);
+    return [
+      for (var i = 0; i < from.length; i++) from[i] + (to[i] - from[i]) * t,
+    ];
+  }
+
+  /// Capture a new from-snapshot to begin a transition.
+  ///
+  /// If an animation is already running, the currently interpolated sizes
+  /// are kept as the new from-snapshot — preserving visual continuity when
+  /// the user reverses direction mid-flight. Otherwise [fallbackFrom] is
+  /// used.
+  void beginCapture(List<double> fallbackFrom) {
+    final newFrom =
+        phase == HideAnimationPhase.animating ? currentSizes! : fallbackFrom;
+    _controller?.stop();
+    _from = newFrom;
+    _to = null;
+  }
+
+  /// Begin the animation toward [target] using [animation].
+  ///
+  /// Must be called after [beginCapture]. Lazily constructs the underlying
+  /// [AnimationController] on first use.
+  void startAnimation({
+    required List<double> target,
+    required ResizableHideAnimation animation,
+  }) {
+    if (_from == null) return;
+
+    _to = target;
+    _curve = animation.curve;
+
+    final controller = _controller ??= AnimationController(vsync: _vsync)
+      ..addListener(_onChanged)
+      ..addStatusListener(_handleStatus);
+
+    controller
+      ..duration = animation.duration
+      ..forward(from: 0.0);
+  }
+
+  /// Stop any in-flight animation and return to [HideAnimationPhase.idle].
+  void cancel() {
+    _controller?.stop();
+    _from = null;
+    _to = null;
+  }
+
+  /// Cancel and dispose the underlying [AnimationController]. The coordinator
+  /// remains reusable; the next [startAnimation] will create a new
+  /// controller.
+  void reset() {
+    final c = _controller;
+    if (c != null) {
+      c
+        ..stop()
+        ..dispose();
+      _controller = null;
+    }
+    _from = null;
+    _to = null;
+  }
+
+  void dispose() => reset();
+
+  void _handleStatus(AnimationStatus status) {
+    // Only react to natural completion. `forward(from: 0.0)` transiently
+    // reports `dismissed` before the new tween starts, and clearing state
+    // there would suppress the new animation entirely.
+    if (status != AnimationStatus.completed) return;
+    _from = null;
+    _to = null;
+    _onChanged();
+  }
+}

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -7,6 +7,7 @@ import 'package:flutter_resizable_container/src/extensions/num_ext.dart';
 import 'package:flutter_resizable_container/src/layout/resizable_layout.dart';
 import 'package:flutter_resizable_container/src/resizable_container_divider.dart';
 import 'package:flutter_resizable_container/src/resizable_controller.dart';
+import 'package:flutter_resizable_container/src/resizable_size.dart';
 
 /// A container that holds multiple child [Widget]s that can be resized.
 ///
@@ -21,6 +22,7 @@ class ResizableContainer extends StatefulWidget {
     required this.direction,
     this.controller,
     this.cascadeNegativeDelta = false,
+    this.hideAnimation,
   });
 
   /// A list of [ResizableChild] containing the child [Widget]s and
@@ -37,14 +39,38 @@ class ResizableContainer extends StatefulWidget {
   /// size of its sibling(s). Defaults to `false`.
   final bool cascadeNegativeDelta;
 
+  /// Optional configuration for animating hide/show transitions triggered by
+  /// [ResizableController.hide] and [ResizableController.show].
+  ///
+  /// When `null` (the default), hidden children collapse and restored
+  /// children expand in a single frame. When non-null, the affected child and
+  /// its siblings tween between their current rendered sizes and the new
+  /// target sizes over [ResizableHideAnimation.duration] using
+  /// [ResizableHideAnimation.curve]. Other size transitions (divider drag,
+  /// [ResizableController.setSizes], available-space changes) remain instant.
+  final ResizableHideAnimation? hideAnimation;
+
   @override
   State<ResizableContainer> createState() => _ResizableContainerState();
 }
 
-class _ResizableContainerState extends State<ResizableContainer> {
+class _ResizableContainerState extends State<ResizableContainer>
+    with SingleTickerProviderStateMixin {
   late final controller = widget.controller ?? ResizableController();
   late final isDefaultController = widget.controller == null;
   late final manager = ResizableControllerManager(controller);
+
+  AnimationController? _animController;
+
+  /// Full alternating list of [child0, divider0, child1, divider1, …, childN]
+  /// pixel sizes captured at the start of an animation.
+  List<double>? _fromSizes;
+
+  /// Full alternating list of pixel sizes the animation tweens toward.
+  List<double>? _toSizes;
+
+  Set<int> _prevHiddenIndices = const <int>{};
+  double? _lastAvailableSpace;
 
   @override
   void initState() {
@@ -52,6 +78,8 @@ class _ResizableContainerState extends State<ResizableContainer> {
 
     manager.initChildren(widget.children);
     manager.setCascadeNegativeDelta(widget.cascadeNegativeDelta);
+    _prevHiddenIndices = Set.of(controller.hiddenIndices);
+    controller.addListener(_onControllerChanged);
   }
 
   @override
@@ -62,7 +90,9 @@ class _ResizableContainerState extends State<ResizableContainer> {
         oldWidget.cascadeNegativeDelta != widget.cascadeNegativeDelta;
 
     if (childrenChanged) {
+      _cancelAnimation();
       controller.setChildren(widget.children);
+      _prevHiddenIndices = Set.of(controller.hiddenIndices);
     }
 
     if (cascadeChanged) {
@@ -73,11 +103,20 @@ class _ResizableContainerState extends State<ResizableContainer> {
       manager.setNeedsLayout();
     }
 
+    if (oldWidget.hideAnimation != widget.hideAnimation &&
+        widget.hideAnimation == null) {
+      _disposeAnimationController();
+      _fromSizes = null;
+      _toSizes = null;
+    }
+
     super.didUpdateWidget(oldWidget);
   }
 
   @override
   void dispose() {
+    controller.removeListener(_onControllerChanged);
+    _disposeAnimationController();
     if (isDefaultController) {
       controller.dispose();
     }
@@ -85,90 +124,332 @@ class _ResizableContainerState extends State<ResizableContainer> {
     super.dispose();
   }
 
+  void _onControllerChanged() {
+    if (!mounted) return;
+
+    final newHidden = controller.hiddenIndices;
+    if (setEquals(newHidden, _prevHiddenIndices)) {
+      return;
+    }
+
+    if (widget.hideAnimation != null) {
+      // Snapshot the currently-displayed sizes — using the PREVIOUS hidden
+      // set for divider visibility, since the controller has already flipped
+      // its hidden state but pixels and dividers are still rendered at the
+      // pre-transition values.
+      final from = _isAnimating
+          ? _interpolatedSizes()
+          : _deriveFullSizesFromController(hiddenIndices: _prevHiddenIndices);
+      _animController?.stop();
+      _fromSizes = from;
+      _toSizes = null;
+    }
+
+    _prevHiddenIndices = Set.of(newHidden);
+  }
+
+  /// Snapshot of the current animation tween at this moment.
+  List<double> _interpolatedSizes() {
+    return _lerpFullSizes(
+      from: _fromSizes!,
+      to: _toSizes!,
+      t: widget.hideAnimation!.curve.transform(_animController!.value),
+    );
+  }
+
+  List<double> _lerpFullSizes({
+    required List<double> from,
+    required List<double> to,
+    required double t,
+  }) {
+    return [
+      for (var i = 0; i < from.length; i++) from[i] + (to[i] - from[i]) * t,
+    ];
+  }
+
+  bool get _isAnimating {
+    final anim = _animController;
+    return anim != null &&
+        anim.isAnimating &&
+        _fromSizes != null &&
+        _toSizes != null;
+  }
+
+  bool get _isCapturingTarget => _fromSizes != null && _toSizes == null;
+
+  void _ensureAnimationController() {
+    _animController ??= AnimationController(vsync: this)
+      ..addListener(_onAnimationTick)
+      ..addStatusListener(_onAnimationStatus);
+  }
+
+  void _disposeAnimationController() {
+    final anim = _animController;
+    if (anim == null) return;
+    anim
+      ..stop()
+      ..dispose();
+    _animController = null;
+  }
+
+  /// Drives a rebuild on every animation tick. AnimatedBuilder below listens
+  /// only to [controller] (whose listener is registered before this widget's
+  /// first build), so a separate hook is needed to pick up animation ticks
+  /// without the per-rebuild churn of `Listenable.merge`.
+  void _onAnimationTick() {
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  void _onAnimationStatus(AnimationStatus status) {
+    // Only react to natural completion. We never call `reverse()`, so a
+    // `dismissed` status only ever appears as a transient side-effect of
+    // `forward(from: 0.0)` resetting the controller's value before the new
+    // tween begins — and clearing the tween state at that point would
+    // suppress the new animation entirely.
+    if (status != AnimationStatus.completed) return;
+    if (!mounted) return;
+    setState(() {
+      _fromSizes = null;
+      _toSizes = null;
+    });
+  }
+
+  void _cancelAnimation() {
+    _animController?.stop();
+    _fromSizes = null;
+    _toSizes = null;
+  }
+
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
         final availableSpace = _getAvailableSpace(constraints);
+
+        if ((_isAnimating || _isCapturingTarget) &&
+            _lastAvailableSpace != null &&
+            availableSpace != _lastAvailableSpace) {
+          _cancelAnimation();
+        }
+        _lastAvailableSpace = availableSpace;
+
         manager.setAvailableSpace(availableSpace);
 
         return AnimatedBuilder(
           animation: controller,
           builder: (context, _) {
-            if (controller.needsLayout) {
-              return ResizableLayout(
-                direction: widget.direction,
-                onComplete: (sizes) {
-                  final childSizes = sizes.evenIndices().toList();
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    manager.setRenderedSizes(childSizes);
-                  });
-                },
-                sizes: controller.sizes,
-                resizableChildren: widget.children,
-                hiddenIndices: controller.hiddenIndices,
+            if (_isAnimating) {
+              return _buildAnimatedFlex(constraints);
+            }
+
+            if (_isCapturingTarget) {
+              return Stack(
+                fit: StackFit.expand,
                 children: [
-                  for (var i = 0; i < widget.children.length; i++) ...[
-                    widget.children[i].child,
-                    if (i < widget.children.length - 1) ...[
-                      ResizableContainerDivider.placeholder(
-                        config: widget.children[i].divider,
-                        direction: widget.direction,
-                      ),
-                    ],
-                  ],
-                ],
-              );
-            } else {
-              return Flex(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                direction: widget.direction,
-                children: [
-                  for (var i = 0; i < widget.children.length; i++) ...[
-                    Builder(
-                      key: widget.children[i].key,
-                      builder: (context) {
-                        final child = widget.children[i].child;
-
-                        final height = _getChildSize(
-                          index: i,
-                          direction: Axis.vertical,
-                          constraints: constraints,
-                        );
-
-                        final width = _getChildSize(
-                          index: i,
-                          direction: Axis.horizontal,
-                          constraints: constraints,
-                        );
-
-                        return SizedBox(
-                          height: height,
-                          width: width,
-                          child: child,
-                        );
-                      },
-                    ),
-                    if (i < widget.children.length - 1) ...[
-                      if (_isDividerHidden(i))
-                        const SizedBox.shrink()
-                      else
-                        ResizableContainerDivider(
-                          config: widget.children[i].divider,
-                          direction: widget.direction,
-                          onResizeUpdate: (delta) => manager.adjustChildSize(
-                            index: i,
-                            delta: delta,
-                          ),
-                        ),
-                    ],
-                  ],
+                  _buildOffstageMeasureLayout(),
+                  _buildFromSizesFlex(constraints),
                 ],
               );
             }
+
+            if (controller.needsLayout) {
+              return _buildLayout(_scheduleSetRenderedSizes);
+            }
+
+            return _buildFlex(constraints);
           },
         );
       },
+    );
+  }
+
+  Widget _buildLayout(ValueChanged<List<double>> onComplete) {
+    return ResizableLayout(
+      direction: widget.direction,
+      onComplete: onComplete,
+      sizes: controller.sizes,
+      resizableChildren: widget.children,
+      hiddenIndices: controller.hiddenIndices,
+      children: [
+        for (var i = 0; i < widget.children.length; i++) ...[
+          widget.children[i].child,
+          if (i < widget.children.length - 1) ...[
+            ResizableContainerDivider.placeholder(
+              config: widget.children[i].divider,
+              direction: widget.direction,
+            ),
+          ],
+        ],
+      ],
+    );
+  }
+
+  Widget _buildOffstageMeasureLayout() {
+    // Run the layout offstage with placeholder children so the real widgets
+    // aren't inflated twice. Any [ResizableSizeShrink] entry is replaced with
+    // a fixed-pixel size based on the controller's last-rendered value — the
+    // shrink dry-layout produced that value already, so it is the size the
+    // offstage pass would otherwise measure.
+    final overrideSizes = <ResizableSize>[
+      for (var i = 0; i < controller.sizes.length; i++)
+        controller.sizes[i] is ResizableSizeShrink
+            ? ResizableSize.pixels(controller.pixels[i])
+            : controller.sizes[i],
+    ];
+
+    return Offstage(
+      offstage: true,
+      child: ResizableLayout(
+        direction: widget.direction,
+        onComplete: _captureTarget,
+        sizes: overrideSizes,
+        resizableChildren: widget.children,
+        hiddenIndices: controller.hiddenIndices,
+        children: [
+          for (var i = 0; i < widget.children.length; i++) ...[
+            const SizedBox.shrink(),
+            if (i < widget.children.length - 1) ...[
+              ResizableContainerDivider.placeholder(
+                config: widget.children[i].divider,
+                direction: widget.direction,
+              ),
+            ],
+          ],
+        ],
+      ),
+    );
+  }
+
+  void _scheduleSetRenderedSizes(List<double> sizes) {
+    final childSizes = sizes.evenIndices().toList();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      manager.setRenderedSizes(childSizes);
+    });
+  }
+
+  void _captureTarget(List<double> sizes) {
+    final fullTarget = List.of(sizes);
+    final childSizes = sizes.evenIndices().toList();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+
+      // If hideAnimation was cleared between the capture-target frame and
+      // this callback, fall back to the instant-snap path.
+      final animation = widget.hideAnimation;
+      if (animation == null) {
+        _fromSizes = null;
+        _toSizes = null;
+        manager.setRenderedSizes(childSizes);
+        return;
+      }
+
+      manager.setRenderedSizes(childSizes);
+      _toSizes = fullTarget;
+      _ensureAnimationController();
+      _animController!
+        ..duration = animation.duration
+        ..forward(from: 0.0);
+    });
+  }
+
+  Widget _buildAnimatedFlex(BoxConstraints constraints) {
+    return _flexFromFullSizes(
+      constraints: constraints,
+      sizes: _interpolatedSizes(),
+    );
+  }
+
+  Widget _buildFromSizesFlex(BoxConstraints constraints) {
+    return _flexFromFullSizes(
+      constraints: constraints,
+      sizes: _fromSizes!,
+    );
+  }
+
+  Widget _buildFlex(BoxConstraints constraints) {
+    return _flexFromFullSizes(
+      constraints: constraints,
+      sizes: _deriveFullSizesFromController(),
+    );
+  }
+
+  List<double> _deriveFullSizesFromController({Set<int>? hiddenIndices}) {
+    final hidden = hiddenIndices ?? controller.hiddenIndices;
+    final result = <double>[];
+    for (var i = 0; i < widget.children.length; i++) {
+      result.add(controller.pixels[i]);
+      if (i < widget.children.length - 1) {
+        final dividerHidden = hidden.contains(i) || hidden.contains(i + 1);
+        final config = widget.children[i].divider;
+        result.add(dividerHidden ? 0.0 : config.thickness + config.padding);
+      }
+    }
+    return result;
+  }
+
+  Widget _flexFromFullSizes({
+    required BoxConstraints constraints,
+    required List<double> sizes,
+  }) {
+    return Flex(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      direction: widget.direction,
+      children: [
+        for (var i = 0; i < widget.children.length; i++) ...[
+          Builder(
+            key: widget.children[i].key,
+            builder: (context) {
+              final child = widget.children[i].child;
+              final mainSize = sizes[i * 2];
+              return SizedBox(
+                width: widget.direction == Axis.horizontal
+                    ? mainSize
+                    : constraints.maxForDirection(Axis.horizontal),
+                height: widget.direction == Axis.vertical
+                    ? mainSize
+                    : constraints.maxForDirection(Axis.vertical),
+                child: child,
+              );
+            },
+          ),
+          if (i < widget.children.length - 1) ...[
+            _buildDividerSlot(
+              dividerIndex: i,
+              size: sizes[i * 2 + 1],
+              constraints: constraints,
+            ),
+          ],
+        ],
+      ],
+    );
+  }
+
+  Widget _buildDividerSlot({
+    required int dividerIndex,
+    required double size,
+    required BoxConstraints constraints,
+  }) {
+    if (size == 0) {
+      return const SizedBox.shrink();
+    }
+    final divider = ResizableContainerDivider(
+      config: widget.children[dividerIndex].divider,
+      direction: widget.direction,
+      onResizeUpdate: (delta) => manager.adjustChildSize(
+        index: dividerIndex,
+        delta: delta,
+      ),
+    );
+    return SizedBox(
+      width: widget.direction == Axis.horizontal
+          ? size
+          : constraints.maxForDirection(Axis.horizontal),
+      height: widget.direction == Axis.vertical
+          ? size
+          : constraints.maxForDirection(Axis.vertical),
+      child: divider,
     );
   }
 
@@ -181,22 +462,5 @@ class _ResizableContainerState extends State<ResizableContainer> {
         .sum();
 
     return totalSpace - dividerSpace;
-  }
-
-  bool _isDividerHidden(int dividerIndex) {
-    return controller.isHidden(dividerIndex) ||
-        controller.isHidden(dividerIndex + 1);
-  }
-
-  double _getChildSize({
-    required int index,
-    required Axis direction,
-    required BoxConstraints constraints,
-  }) {
-    if (widget.direction != direction) {
-      return constraints.maxForDirection(direction);
-    } else {
-      return controller.pixels[index];
-    }
   }
 }

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -4,6 +4,7 @@ import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 import 'package:flutter_resizable_container/src/extensions/box_constraints_ext.dart';
 import 'package:flutter_resizable_container/src/extensions/iterable_ext.dart';
 import 'package:flutter_resizable_container/src/extensions/num_ext.dart';
+import 'package:flutter_resizable_container/src/hide_animation_coordinator.dart';
 import 'package:flutter_resizable_container/src/layout/resizable_layout.dart';
 import 'package:flutter_resizable_container/src/resizable_container_divider.dart';
 import 'package:flutter_resizable_container/src/resizable_controller.dart';
@@ -60,14 +61,10 @@ class _ResizableContainerState extends State<ResizableContainer>
   late final isDefaultController = widget.controller == null;
   late final manager = ResizableControllerManager(controller);
 
-  AnimationController? _animController;
-
-  /// Full alternating list of [child0, divider0, child1, divider1, …, childN]
-  /// pixel sizes captured at the start of an animation.
-  List<double>? _fromSizes;
-
-  /// Full alternating list of pixel sizes the animation tweens toward.
-  List<double>? _toSizes;
+  late final _animation = HideAnimationCoordinator(
+    vsync: this,
+    onChanged: _rebuild,
+  );
 
   Set<int> _prevHiddenIndices = const <int>{};
   double? _lastAvailableSpace;
@@ -90,7 +87,7 @@ class _ResizableContainerState extends State<ResizableContainer>
         oldWidget.cascadeNegativeDelta != widget.cascadeNegativeDelta;
 
     if (childrenChanged) {
-      _cancelAnimation();
+      _animation.cancel();
       controller.setChildren(widget.children);
       _prevHiddenIndices = Set.of(controller.hiddenIndices);
     }
@@ -105,9 +102,7 @@ class _ResizableContainerState extends State<ResizableContainer>
 
     if (oldWidget.hideAnimation != widget.hideAnimation &&
         widget.hideAnimation == null) {
-      _disposeAnimationController();
-      _fromSizes = null;
-      _toSizes = null;
+      _animation.reset();
     }
 
     super.didUpdateWidget(oldWidget);
@@ -116,12 +111,17 @@ class _ResizableContainerState extends State<ResizableContainer>
   @override
   void dispose() {
     controller.removeListener(_onControllerChanged);
-    _disposeAnimationController();
+    _animation.dispose();
     if (isDefaultController) {
       controller.dispose();
     }
 
     super.dispose();
+  }
+
+  void _rebuild() {
+    if (!mounted) return;
+    setState(() {});
   }
 
   void _onControllerChanged() {
@@ -133,92 +133,15 @@ class _ResizableContainerState extends State<ResizableContainer>
     }
 
     if (widget.hideAnimation != null) {
-      // Snapshot the currently-displayed sizes — using the PREVIOUS hidden
-      // set for divider visibility, since the controller has already flipped
-      // its hidden state but pixels and dividers are still rendered at the
-      // pre-transition values.
-      final from = _isAnimating
-          ? _interpolatedSizes()
-          : _deriveFullSizesFromController(hiddenIndices: _prevHiddenIndices);
-      _animController?.stop();
-      _fromSizes = from;
-      _toSizes = null;
+      // The controller has already flipped its hidden state, but pixels and
+      // dividers are still rendered at the pre-transition values, so the
+      // from-snapshot must be derived against the previous hidden set.
+      _animation.beginCapture(
+        _deriveFullSizesFromController(hiddenIndices: _prevHiddenIndices),
+      );
     }
 
     _prevHiddenIndices = Set.of(newHidden);
-  }
-
-  /// Snapshot of the current animation tween at this moment.
-  List<double> _interpolatedSizes() {
-    return _lerpFullSizes(
-      from: _fromSizes!,
-      to: _toSizes!,
-      t: widget.hideAnimation!.curve.transform(_animController!.value),
-    );
-  }
-
-  List<double> _lerpFullSizes({
-    required List<double> from,
-    required List<double> to,
-    required double t,
-  }) {
-    return [
-      for (var i = 0; i < from.length; i++) from[i] + (to[i] - from[i]) * t,
-    ];
-  }
-
-  bool get _isAnimating {
-    final anim = _animController;
-    return anim != null &&
-        anim.isAnimating &&
-        _fromSizes != null &&
-        _toSizes != null;
-  }
-
-  bool get _isCapturingTarget => _fromSizes != null && _toSizes == null;
-
-  void _ensureAnimationController() {
-    _animController ??= AnimationController(vsync: this)
-      ..addListener(_onAnimationTick)
-      ..addStatusListener(_onAnimationStatus);
-  }
-
-  void _disposeAnimationController() {
-    final anim = _animController;
-    if (anim == null) return;
-    anim
-      ..stop()
-      ..dispose();
-    _animController = null;
-  }
-
-  /// Drives a rebuild on every animation tick. AnimatedBuilder below listens
-  /// only to [controller] (whose listener is registered before this widget's
-  /// first build), so a separate hook is needed to pick up animation ticks
-  /// without the per-rebuild churn of `Listenable.merge`.
-  void _onAnimationTick() {
-    if (!mounted) return;
-    setState(() {});
-  }
-
-  void _onAnimationStatus(AnimationStatus status) {
-    // Only react to natural completion. We never call `reverse()`, so a
-    // `dismissed` status only ever appears as a transient side-effect of
-    // `forward(from: 0.0)` resetting the controller's value before the new
-    // tween begins — and clearing the tween state at that point would
-    // suppress the new animation entirely.
-    if (status != AnimationStatus.completed) return;
-    if (!mounted) return;
-    setState(() {
-      _fromSizes = null;
-      _toSizes = null;
-    });
-  }
-
-  void _cancelAnimation() {
-    _animController?.stop();
-    _fromSizes = null;
-    _toSizes = null;
   }
 
   @override
@@ -227,10 +150,10 @@ class _ResizableContainerState extends State<ResizableContainer>
       builder: (context, constraints) {
         final availableSpace = _getAvailableSpace(constraints);
 
-        if ((_isAnimating || _isCapturingTarget) &&
+        if (_animation.phase != HideAnimationPhase.idle &&
             _lastAvailableSpace != null &&
             availableSpace != _lastAvailableSpace) {
-          _cancelAnimation();
+          _animation.cancel();
         }
         _lastAvailableSpace = availableSpace;
 
@@ -238,30 +161,41 @@ class _ResizableContainerState extends State<ResizableContainer>
 
         return AnimatedBuilder(
           animation: controller,
-          builder: (context, _) {
-            if (_isAnimating) {
-              return _buildAnimatedFlex(constraints);
-            }
-
-            if (_isCapturingTarget) {
-              return Stack(
-                fit: StackFit.expand,
-                children: [
-                  _buildOffstageMeasureLayout(),
-                  _buildFromSizesFlex(constraints),
-                ],
-              );
-            }
-
-            if (controller.needsLayout) {
-              return _buildLayout(_scheduleSetRenderedSizes);
-            }
-
-            return _buildFlex(constraints);
-          },
+          builder: (context, _) => _buildForPhase(constraints),
         );
       },
     );
+  }
+
+  Widget _buildForPhase(BoxConstraints constraints) {
+    switch (_animation.phase) {
+      case HideAnimationPhase.animating:
+        return _flexFromFullSizes(
+          constraints: constraints,
+          sizes: _animation.currentSizes!,
+        );
+
+      case HideAnimationPhase.capturing:
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            _buildOffstageMeasureLayout(),
+            _flexFromFullSizes(
+              constraints: constraints,
+              sizes: _animation.currentSizes!,
+            ),
+          ],
+        );
+
+      case HideAnimationPhase.idle:
+        if (controller.needsLayout) {
+          return _buildLayout(_scheduleSetRenderedSizes);
+        }
+        return _flexFromFullSizes(
+          constraints: constraints,
+          sizes: _deriveFullSizesFromController(),
+        );
+    }
   }
 
   Widget _buildLayout(ValueChanged<List<double>> onComplete) {
@@ -271,17 +205,7 @@ class _ResizableContainerState extends State<ResizableContainer>
       sizes: controller.sizes,
       resizableChildren: widget.children,
       hiddenIndices: controller.hiddenIndices,
-      children: [
-        for (var i = 0; i < widget.children.length; i++) ...[
-          widget.children[i].child,
-          if (i < widget.children.length - 1) ...[
-            ResizableContainerDivider.placeholder(
-              config: widget.children[i].divider,
-              direction: widget.direction,
-            ),
-          ],
-        ],
-      ],
+      children: _buildLayoutChildren((i) => widget.children[i].child),
     );
   }
 
@@ -306,19 +230,26 @@ class _ResizableContainerState extends State<ResizableContainer>
         sizes: overrideSizes,
         resizableChildren: widget.children,
         hiddenIndices: controller.hiddenIndices,
-        children: [
-          for (var i = 0; i < widget.children.length; i++) ...[
-            const SizedBox.shrink(),
-            if (i < widget.children.length - 1) ...[
-              ResizableContainerDivider.placeholder(
-                config: widget.children[i].divider,
-                direction: widget.direction,
-              ),
-            ],
-          ],
-        ],
+        children: _buildLayoutChildren((_) => const SizedBox.shrink()),
       ),
     );
+  }
+
+  /// Builds the alternating child/divider list that [ResizableLayout]
+  /// expects. [childBuilder] supplies the widget rendered for each child
+  /// slot — the real child for the live layout, a placeholder for the
+  /// offstage measurement.
+  List<Widget> _buildLayoutChildren(Widget Function(int index) childBuilder) {
+    return [
+      for (var i = 0; i < widget.children.length; i++) ...[
+        childBuilder(i),
+        if (i < widget.children.length - 1)
+          ResizableContainerDivider.placeholder(
+            config: widget.children[i].divider,
+            direction: widget.direction,
+          ),
+      ],
+    ];
   }
 
   void _scheduleSetRenderedSizes(List<double> sizes) {
@@ -335,44 +266,18 @@ class _ResizableContainerState extends State<ResizableContainer>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
 
+      manager.setRenderedSizes(childSizes);
+
       // If hideAnimation was cleared between the capture-target frame and
       // this callback, fall back to the instant-snap path.
       final animation = widget.hideAnimation;
       if (animation == null) {
-        _fromSizes = null;
-        _toSizes = null;
-        manager.setRenderedSizes(childSizes);
+        _animation.cancel();
         return;
       }
 
-      manager.setRenderedSizes(childSizes);
-      _toSizes = fullTarget;
-      _ensureAnimationController();
-      _animController!
-        ..duration = animation.duration
-        ..forward(from: 0.0);
+      _animation.startAnimation(target: fullTarget, animation: animation);
     });
-  }
-
-  Widget _buildAnimatedFlex(BoxConstraints constraints) {
-    return _flexFromFullSizes(
-      constraints: constraints,
-      sizes: _interpolatedSizes(),
-    );
-  }
-
-  Widget _buildFromSizesFlex(BoxConstraints constraints) {
-    return _flexFromFullSizes(
-      constraints: constraints,
-      sizes: _fromSizes!,
-    );
-  }
-
-  Widget _buildFlex(BoxConstraints constraints) {
-    return _flexFromFullSizes(
-      constraints: constraints,
-      sizes: _deriveFullSizesFromController(),
-    );
   }
 
   List<double> _deriveFullSizesFromController({Set<int>? hiddenIndices}) {
@@ -401,7 +306,6 @@ class _ResizableContainerState extends State<ResizableContainer>
           Builder(
             key: widget.children[i].key,
             builder: (context) {
-              final child = widget.children[i].child;
               final mainSize = sizes[i * 2];
               return SizedBox(
                 width: widget.direction == Axis.horizontal
@@ -410,17 +314,16 @@ class _ResizableContainerState extends State<ResizableContainer>
                 height: widget.direction == Axis.vertical
                     ? mainSize
                     : constraints.maxForDirection(Axis.vertical),
-                child: child,
+                child: widget.children[i].child,
               );
             },
           ),
-          if (i < widget.children.length - 1) ...[
+          if (i < widget.children.length - 1)
             _buildDividerSlot(
               dividerIndex: i,
               size: sizes[i * 2 + 1],
               constraints: constraints,
             ),
-          ],
         ],
       ],
     );

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -56,7 +56,7 @@ class ResizableContainer extends StatefulWidget {
 }
 
 class _ResizableContainerState extends State<ResizableContainer>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   late final controller = widget.controller ?? ResizableController();
   late final isDefaultController = widget.controller == null;
   late final manager = ResizableControllerManager(controller);

--- a/lib/src/resizable_hide_animation.dart
+++ b/lib/src/resizable_hide_animation.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/widgets.dart';
+
+/// Configuration for the implicit animation that runs when a child of a
+/// [ResizableContainer] is hidden or shown via [ResizableController.hide] or
+/// [ResizableController.show].
+///
+/// Pass an instance to [ResizableContainer.hideAnimation] to opt in. When
+/// `null` (the default), hide/show transitions snap to their target in a
+/// single frame.
+class ResizableHideAnimation {
+  /// Creates a [ResizableHideAnimation] with the given [duration] and [curve].
+  const ResizableHideAnimation({
+    this.duration = const Duration(milliseconds: 200),
+    this.curve = Curves.easeInOut,
+  });
+
+  /// The total length of the hide or show transition.
+  ///
+  /// Defaults to 200 milliseconds.
+  final Duration duration;
+
+  /// The curve applied to the animation's progress.
+  ///
+  /// Defaults to [Curves.easeInOut].
+  final Curve curve;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ResizableHideAnimation &&
+          other.duration == duration &&
+          other.curve == curve;
+
+  @override
+  int get hashCode => Object.hash(duration, curve);
+}

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -1458,6 +1458,499 @@ void main() {
         expect(boxCSize.width, equals(95));
       });
     });
+
+    group('hideAnimation', () {
+      Widget buildHarness({
+        required ResizableController controller,
+        ResizableHideAnimation? hideAnimation,
+      }) {
+        return MaterialApp(
+          home: Scaffold(
+            body: ResizableContainer(
+              controller: controller,
+              direction: Axis.horizontal,
+              hideAnimation: hideAnimation,
+              children: const [
+                ResizableChild(
+                  size: ResizableSize.pixels(200),
+                  divider: ResizableDivider(thickness: 2),
+                  child: SizedBox.expand(key: Key('A')),
+                ),
+                ResizableChild(
+                  size: ResizableSize.pixels(200),
+                  divider: ResizableDivider(thickness: 2),
+                  child: SizedBox.expand(key: Key('B')),
+                ),
+                ResizableChild(
+                  size: ResizableSize.expand(),
+                  child: SizedBox.expand(key: Key('C')),
+                ),
+              ],
+            ),
+          ),
+        );
+      }
+
+      testWidgets(
+        'collapses immediately when hideAnimation is null',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(buildHarness(controller: controller));
+          await tester.pumpAndSettle();
+
+          controller.hide(1);
+          await tester.pumpAndSettle();
+
+          expect(tester.getSize(find.byKey(const Key('B'))).width, 0);
+          // Both dividers adjacent to the hidden child are also removed.
+          expect(find.byType(ResizableContainerDivider), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'interpolates the hidden child width between start and target',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final initialWidth = tester.getSize(find.byKey(const Key('B'))).width;
+          expect(initialWidth, 200);
+
+          controller.hide(1);
+          // pump #1: capture-target frame, schedules animation start in
+          // its post-frame callback.
+          await tester.pump();
+          // pump #2: first ticker tick — Ticker captures its start time on
+          // the first tick, so elapsed is 0 here.
+          await tester.pump();
+          // pump #3: advances halfway through the 200ms animation.
+          await tester.pump(const Duration(milliseconds: 100));
+
+          final midWidth = tester.getSize(find.byKey(const Key('B'))).width;
+          expect(midWidth, lessThan(initialWidth));
+          expect(midWidth, greaterThan(0));
+        },
+      );
+
+      testWidgets(
+        'reaches zero width and lets siblings absorb the freed space',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(1);
+          await tester.pumpAndSettle();
+
+          expect(tester.getSize(find.byKey(const Key('B'))).width, 0);
+          // A=200, B=0, dividers collapsed, so C absorbs the rest.
+          expect(
+            tester.getSize(find.byKey(const Key('C'))).width,
+            equals(400),
+          );
+        },
+      );
+
+      testWidgets(
+        'keeps the adjacent divider in the tree during the collapse',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(1);
+          await tester.pump();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 50));
+
+          // Both dividers adjacent to the collapsing child are still
+          // rendered during the in-flight collapse.
+          expect(find.byType(ResizableContainerDivider), findsNWidgets(2));
+        },
+      );
+
+      testWidgets(
+        'removes the adjacent divider once the animation settles',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(1);
+          await tester.pumpAndSettle();
+
+          // Both dividers adjacent to the hidden child are removed.
+          expect(find.byType(ResizableContainerDivider), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'animates the restored size on show',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(1);
+          await tester.pumpAndSettle();
+          expect(tester.getSize(find.byKey(const Key('B'))).width, 0);
+
+          controller.show(1);
+          await tester.pump();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          final midWidth = tester.getSize(find.byKey(const Key('B'))).width;
+          expect(midWidth, greaterThan(0));
+          expect(midWidth, lessThan(200));
+
+          await tester.pumpAndSettle();
+          expect(tester.getSize(find.byKey(const Key('B'))).width, 200);
+        },
+      );
+
+      testWidgets(
+        'preserves continuity when show is called mid-hide',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(1);
+          // Two pumps to seed the Ticker, then advance halfway.
+          await tester.pump();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          final widthBeforeShow =
+              tester.getSize(find.byKey(const Key('B'))).width;
+          expect(widthBeforeShow, greaterThan(0));
+          expect(widthBeforeShow, lessThan(200));
+
+          controller.show(1);
+          await tester.pump();
+
+          final widthAfterShow =
+              tester.getSize(find.byKey(const Key('B'))).width;
+          // The first frame after `show` should mirror the from-snapshot,
+          // i.e. the displayed width at the moment `show` was called.
+          expect(
+            widthAfterShow,
+            closeTo(widthBeforeShow, 1.0),
+          );
+        },
+      );
+
+      testWidgets(
+        'cancels the animation when available space changes mid-flight',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(1);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          await tester.binding.setSurfaceSize(const Size(800, 400));
+          await tester.pumpAndSettle();
+
+          // After the resize, the hidden child still has zero width and the
+          // remaining children absorb the new available space.
+          expect(tester.getSize(find.byKey(const Key('B'))).width, 0);
+          final aWidth = tester.getSize(find.byKey(const Key('A'))).width;
+          final cWidth = tester.getSize(find.byKey(const Key('C'))).width;
+          expect(aWidth, 200);
+          expect(cWidth, equals(800 - aWidth));
+        },
+      );
+
+      testWidgets(
+        'leaves no pending timers when disposed mid-flight',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(1);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 50));
+
+          // Replace the harness with an empty widget — the previous
+          // container's State is disposed.
+          await tester.pumpWidget(const SizedBox());
+          await tester.pump();
+
+          expect(tester.binding.transientCallbackCount, 0);
+        },
+      );
+
+      testWidgets(
+        'controller.isHidden reflects the intent immediately',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(0);
+          // Without any pump, the controller's reported intent is already
+          // hidden, even though the visual transition has not begun.
+          expect(controller.isHidden(0), isTrue);
+
+          await tester.pumpAndSettle();
+        },
+      );
+
+      testWidgets(
+        'batches consecutive hides into a single animation',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(0);
+          controller.hide(1);
+          await tester.pump();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          // Both children interpolate inside the same animation — at the
+          // halfway mark each width is strictly between its start and 0.
+          final aWidth = tester.getSize(find.byKey(const Key('A'))).width;
+          final bWidth = tester.getSize(find.byKey(const Key('B'))).width;
+          expect(aWidth, greaterThan(0));
+          expect(aWidth, lessThan(200));
+          expect(bWidth, greaterThan(0));
+          expect(bWidth, lessThan(200));
+
+          await tester.pumpAndSettle();
+          expect(tester.getSize(find.byKey(const Key('A'))).width, 0);
+          expect(tester.getSize(find.byKey(const Key('B'))).width, 0);
+        },
+      );
+
+      testWidgets(
+        'disposes the animation controller when hideAnimation is removed '
+        'mid-flight',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          Widget appWithAnimation(ResizableHideAnimation? animation) {
+            return MaterialApp(
+              home: Scaffold(
+                body: ResizableContainer(
+                  controller: controller,
+                  direction: Axis.horizontal,
+                  hideAnimation: animation,
+                  children: const [
+                    ResizableChild(
+                      size: ResizableSize.pixels(200),
+                      divider: ResizableDivider(thickness: 2),
+                      child: SizedBox.expand(key: Key('A')),
+                    ),
+                    ResizableChild(
+                      size: ResizableSize.pixels(200),
+                      divider: ResizableDivider(thickness: 2),
+                      child: SizedBox.expand(key: Key('B')),
+                    ),
+                    ResizableChild(
+                      size: ResizableSize.expand(),
+                      child: SizedBox.expand(key: Key('C')),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          await tester.pumpWidget(
+            appWithAnimation(const ResizableHideAnimation()),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(1);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 50));
+
+          // Remove the animation config while the tween is still running.
+          await tester.pumpWidget(appWithAnimation(null));
+          await tester.pump();
+
+          // The hidden child snaps to its target (0) and no pending animation
+          // timers remain.
+          expect(tester.getSize(find.byKey(const Key('B'))).width, 0);
+          expect(tester.binding.transientCallbackCount, 0);
+        },
+      );
+
+      testWidgets(
+        'animates the next hide after hideAnimation switches on',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          Widget appWithAnimation(ResizableHideAnimation? animation) {
+            return MaterialApp(
+              home: Scaffold(
+                body: ResizableContainer(
+                  controller: controller,
+                  direction: Axis.horizontal,
+                  hideAnimation: animation,
+                  children: const [
+                    ResizableChild(
+                      size: ResizableSize.pixels(200),
+                      divider: ResizableDivider(thickness: 2),
+                      child: SizedBox.expand(key: Key('A')),
+                    ),
+                    ResizableChild(
+                      size: ResizableSize.pixels(200),
+                      divider: ResizableDivider(thickness: 2),
+                      child: SizedBox.expand(key: Key('B')),
+                    ),
+                    ResizableChild(
+                      size: ResizableSize.expand(),
+                      child: SizedBox.expand(key: Key('C')),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          await tester.pumpWidget(appWithAnimation(null));
+          await tester.pumpAndSettle();
+
+          // Switch animation on after first build.
+          await tester.pumpWidget(
+            appWithAnimation(const ResizableHideAnimation()),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(1);
+          await tester.pump();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          final midWidth = tester.getSize(find.byKey(const Key('B'))).width;
+          expect(midWidth, greaterThan(0));
+          expect(midWidth, lessThan(200));
+        },
+      );
+
+      testWidgets(
+        'controller.pixels reports the target value after hide',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(600, 400));
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.pumpWidget(
+            buildHarness(
+              controller: controller,
+              hideAnimation: const ResizableHideAnimation(),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.hide(0);
+          await tester.pump();
+
+          // The container has captured the target via the offstage layout
+          // and pushed it into the controller — so pixels[0] is 0 well
+          // before the visible transition finishes.
+          expect(controller.pixels[0], 0);
+
+          await tester.pumpAndSettle();
+        },
+      );
+    });
   });
 }
 

--- a/test/resizable_hide_animation_test.dart
+++ b/test/resizable_hide_animation_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/animation.dart';
+import 'package:flutter_resizable_container/flutter_resizable_container.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(ResizableHideAnimation, () {
+    test('defaults to a 200ms easeInOut animation', () {
+      const animation = ResizableHideAnimation();
+
+      expect(animation.duration, const Duration(milliseconds: 200));
+      expect(animation.curve, Curves.easeInOut);
+    });
+
+    test('two instances with the same fields are equal', () {
+      const a = ResizableHideAnimation(
+        duration: Duration(milliseconds: 300),
+        curve: Curves.linear,
+      );
+      const b = ResizableHideAnimation(
+        duration: Duration(milliseconds: 300),
+        curve: Curves.linear,
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('differs when duration differs', () {
+      const a = ResizableHideAnimation(
+        duration: Duration(milliseconds: 100),
+      );
+      const b = ResizableHideAnimation(
+        duration: Duration(milliseconds: 200),
+      );
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differs when curve differs', () {
+      const a = ResizableHideAnimation(curve: Curves.linear);
+      const b = ResizableHideAnimation(curve: Curves.easeIn);
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds an opt-in animation to `ResizableContainer` so calls to `ResizableController.hide(i)` / `show(i)` tween the affected child and its siblings between their current rendered sizes and the new targets — instead of snapping in a single frame.

- New `ResizableHideAnimation` value type (`duration`, `curve`)
- New optional `ResizableContainer.hideAnimation` parameter; defaults to `null` (instant snap — fully backwards-compatible)
- Container owns the `AnimationController`; the controller's public surface is untouched
- All other size transitions (drag, `setSizes`, available-space changes) remain instant

Closes #90.

## Implementation notes

- The container measures the target layout offstage (via `ResizableLayout` with placeholder children and substituted sizes for `ResizableSize.shrink`) so it can capture the post-hide pixel values without painting a single frame at the target.
- During the tween, the container interpolates the full alternating list of child and divider sizes — preserving the total along the main axis on every frame. Dividers stay rendered until the adjacent child's *displayed* size reaches 0.
- `controller.isHidden(i)` reports the intent immediately; `controller.pixels[i]` reports the target value as soon as it is captured. The animation lives in the container, not in the controller.

## Test plan

- [x] `flutter analyze` is clean
- [x] Full test suite passes (`very_good test`)
- [x] 14 new widget tests covering: instant-snap default, interpolation, sibling absorption, divider visibility during/after collapse, animated show, mid-flight hide→show continuity, mid-flight available-space change, dispose mid-flight, `isHidden` / `pixels` semantics, batched hides in one frame, runtime `hideAnimation` toggle on and off
- [x] 4 new tests for the `ResizableHideAnimation` value type (defaults, equality, hashCode)
- [x] All existing tests pass unchanged