### PR TITLE
fix: clamp cascaded delta by receiver max constraint

### DIFF
--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -144,8 +144,17 @@ class ResizableController with ChangeNotifier {
       if (delta < 0) {
         // and the divider is being dragged to the left
 
+        // cap the cascaded delta so the right neighbor (the receiver of the
+        // freed space) cannot grow past its max constraint
+        final maxGrowth =
+            (_sizes[index + 1].max ?? double.infinity) - _pixels[index + 1];
+        final cascadeDelta = -min(delta.abs(), maxGrowth);
+
         // distribute the delta amongst the leftward siblings
-        final changes = _distributeDeltaLeft(index: index, delta: delta);
+        final changes = _distributeDeltaLeft(
+          index: index,
+          delta: cascadeDelta,
+        );
 
         // apply the distribution outward from the selected index
         for (var i = 0; i < changes.length; i++) {
@@ -162,8 +171,17 @@ class ResizableController with ChangeNotifier {
       } else {
         // and the divider is being dragged to the right
 
+        // cap the cascaded delta so the selected index (the receiver of the
+        // freed space) cannot grow past its max constraint
+        final maxGrowth =
+            (_sizes[index].max ?? double.infinity) - _pixels[index];
+        final cascadeDelta = min(delta, maxGrowth);
+
         // distribute the delta amongst the rightward siblings
-        final changes = _distributeDeltaRight(index: index, delta: delta);
+        final changes = _distributeDeltaRight(
+          index: index,
+          delta: cascadeDelta,
+        );
 
         // apply the distribution outward from the selected index
         for (var i = 0; i < changes.length; i++) {

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -291,6 +291,125 @@ void main() {
       });
     });
 
+    group('#adjustChildSize with cascadeNegativeDelta', () {
+      group('when dragging right (delta > 0)', () {
+        test(
+          'does not grow the selected child past its max constraint',
+          () {
+            controller.setChildren(const [
+              ResizableChild(
+                size: ResizableSize.pixels(50),
+                child: SizedBox.shrink(),
+              ),
+              ResizableChild(
+                size: ResizableSize.pixels(60, max: 70),
+                child: SizedBox.shrink(),
+              ),
+              ResizableChild(
+                size: ResizableSize.pixels(50, min: 20),
+                child: SizedBox.shrink(),
+              ),
+              ResizableChild(
+                size: ResizableSize.pixels(40, min: 20),
+                child: SizedBox.shrink(),
+              ),
+            ]);
+
+            manager.setAvailableSpace(200);
+            manager.setRenderedSizes([50, 60, 50, 40]);
+            manager.setCascadeNegativeDelta(true);
+
+            // Drag divider after index=1 far to the right. Index 2 can only
+            // give up 30 (50 -> 20) and index 3 can give up 20 (40 -> 20),
+            // which would naively grow index 1 by 50 -> 110, well past its
+            // max of 70. The cascade must clamp at the max.
+            manager.adjustChildSize(index: 1, delta: 100);
+
+            expect(controller.pixels[1], lessThanOrEqualTo(70));
+            expect(controller.pixels[1], equals(70));
+            // total width is preserved
+            expect(controller.pixels.reduce((a, b) => a + b), equals(200));
+          },
+        );
+
+        test(
+          'shrinks rightward siblings only by what the selected child can absorb',
+          () {
+            controller.setChildren(const [
+              ResizableChild(
+                size: ResizableSize.pixels(50),
+                child: SizedBox.shrink(),
+              ),
+              ResizableChild(
+                size: ResizableSize.pixels(60, max: 70),
+                child: SizedBox.shrink(),
+              ),
+              ResizableChild(
+                size: ResizableSize.pixels(50, min: 20),
+                child: SizedBox.shrink(),
+              ),
+              ResizableChild(
+                size: ResizableSize.pixels(40, min: 20),
+                child: SizedBox.shrink(),
+              ),
+            ]);
+
+            manager.setAvailableSpace(200);
+            manager.setRenderedSizes([50, 60, 50, 40]);
+            manager.setCascadeNegativeDelta(true);
+
+            manager.adjustChildSize(index: 1, delta: 100);
+
+            // index 1 only had room for +10 (60 -> 70). That 10 must come
+            // entirely from the immediate neighbor; the outer sibling stays.
+            expect(controller.pixels[2], equals(40));
+            expect(controller.pixels[3], equals(40));
+          },
+        );
+      });
+
+      group('when dragging left (delta < 0)', () {
+        test(
+          'does not grow the right sibling past its max constraint',
+          () {
+            controller.setChildren(const [
+              ResizableChild(
+                size: ResizableSize.pixels(40, min: 20),
+                child: SizedBox.shrink(),
+              ),
+              ResizableChild(
+                size: ResizableSize.pixels(50, min: 20),
+                child: SizedBox.shrink(),
+              ),
+              ResizableChild(
+                size: ResizableSize.pixels(60, min: 20),
+                child: SizedBox.shrink(),
+              ),
+              ResizableChild(
+                size: ResizableSize.pixels(50, max: 60),
+                child: SizedBox.shrink(),
+              ),
+            ]);
+
+            manager.setAvailableSpace(200);
+            manager.setRenderedSizes([40, 50, 60, 50]);
+            manager.setCascadeNegativeDelta(true);
+
+            // Drag divider after index=2 to the left. Index 2 is at min 20
+            // possible (60 -> 20 = 40 freed), index 1 (50 -> 20 = 30), index
+            // 0 (40 -> 20 = 20). Naively, that could grow index 3 by up to
+            // 90 to 140 — past its max of 60.
+            manager.adjustChildSize(index: 2, delta: -100);
+
+            expect(controller.pixels[3], lessThanOrEqualTo(60));
+            expect(controller.pixels[3], equals(60));
+            // total width is preserved
+            expect(controller.pixels.reduce((a, b) => a + b), equals(200));
+          },
+        );
+      });
+    });
+
     group('#setSizes', () {
       setUp(() {
         controller.setChildren(const [


### PR DESCRIPTION
Closes #106.

## Summary

- In `_adjustChildSize`, the cascade branch grew the receiver cell by `changes.sum().abs()` without re-checking its `max`. When siblings could collectively give up more space than the receiver could absorb, the receiver overflowed its max and total width drifted from `availableSpace`.
- Cap the cascaded delta by `(_sizes[receiver].max ?? infinity) - _pixels[receiver]` before distributing across siblings. Applied symmetrically to both branches: the right-drag receiver is `index`; the left-drag receiver is `index + 1` (the asymmetric branch noted in the issue).
- Added tests covering both max/min boundary behaviors under cascading.

## Test plan

- [x] `very_good test` passes
- [x] New tests cover right-drag receiver max clamp
- [x] New tests cover left-drag receiver max clamp
- [x] New tests verify rightward siblings only shrink by what receiver can absorb
- [x] Total width is preserved after the clamp in both branches