### PR TITLE
fix: ResizableChild.props omits divider and discards child widget

### DIFF
--- a/lib/src/resizable_child.dart
+++ b/lib/src/resizable_child.dart
@@ -48,5 +48,5 @@ class ResizableChild extends Equatable {
   bool get stringify => true;
 
   @override
-  List<Object?> get props => [size, child.key, child.runtimeType];
+  List<Object?> get props => [size, divider, child];
 }

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -86,7 +86,10 @@ class _ResizableContainerState extends State<ResizableContainer>
   @override
   void didUpdateWidget(covariant ResizableContainer oldWidget) {
     final controllerChanged = oldWidget.controller != widget.controller;
-    final childrenChanged = !listEquals(oldWidget.children, widget.children);
+    final structuralChange =
+        _isStructuralChange(oldWidget.children, widget.children);
+    final configChange =
+        !structuralChange && !listEquals(oldWidget.children, widget.children);
     final directionChanged = oldWidget.direction != widget.direction;
     final cascadeChanged =
         oldWidget.cascadeNegativeDelta != widget.cascadeNegativeDelta;
@@ -107,17 +110,19 @@ class _ResizableContainerState extends State<ResizableContainer>
       _prevHiddenIndices = Set.of(controller.hiddenIndices);
       _lastAvailableSpace = null;
       controller.addListener(_onControllerChanged);
-    } else if (childrenChanged) {
+    } else if (structuralChange) {
       _animation.cancel();
       controller.setChildren(widget.children);
       _prevHiddenIndices = Set.of(controller.hiddenIndices);
+    } else if (configChange) {
+      manager.updateChildrenInPlace(widget.children);
     }
 
     if (!controllerChanged && cascadeChanged) {
       manager.setCascadeNegativeDelta(widget.cascadeNegativeDelta);
     }
 
-    if (!controllerChanged && (childrenChanged || directionChanged)) {
+    if (!controllerChanged && (structuralChange || directionChanged)) {
       manager.setNeedsLayout();
     }
 
@@ -127,6 +132,25 @@ class _ResizableContainerState extends State<ResizableContainer>
     }
 
     super.didUpdateWidget(oldWidget);
+  }
+
+  /// Whether [oldChildren] and [newChildren] differ in ways that invalidate
+  /// the controller's layout state — the number of children or any of their
+  /// declared sizes. Differences confined to divider config or child widget
+  /// instances are not structural.
+  bool _isStructuralChange(
+    List<ResizableChild> oldChildren,
+    List<ResizableChild> newChildren,
+  ) {
+    if (oldChildren.length != newChildren.length) {
+      return true;
+    }
+    for (var i = 0; i < oldChildren.length; i++) {
+      if (oldChildren[i].size != newChildren[i].size) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @override

--- a/lib/src/resizable_controller.dart
+++ b/lib/src/resizable_controller.dart
@@ -227,6 +227,16 @@ class ResizableController with ChangeNotifier {
     }
   }
 
+  /// Rebinds [_children] without resetting pixel, hidden, or saved-size state.
+  ///
+  /// Used when the children list differs only in non-structural ways (e.g. a
+  /// new divider config or a new child widget instance) — the declared sizes
+  /// and child count are unchanged, so the controller's layout state remains
+  /// valid.
+  void _updateChildrenInPlace(List<ResizableChild> children) {
+    _children = children;
+  }
+
   void _setRenderedSizes(List<double> pixels) {
     _pixels = pixels;
     _needsLayout = false;
@@ -540,6 +550,13 @@ final class ResizableControllerManager {
 
   void initChildren(List<ResizableChild> children) {
     _controller._initChildren(children);
+  }
+
+  /// Rebinds the controller's children list without resetting any layout
+  /// state. Use when the new children differ only in non-structural ways
+  /// (e.g. divider config or child widget instances).
+  void updateChildrenInPlace(List<ResizableChild> children) {
+    _controller._updateChildrenInPlace(children);
   }
 
   void setCascadeNegativeDelta(bool cascadeNegativeDelta) {

--- a/test/resizable_child_test.dart
+++ b/test/resizable_child_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_resizable_container/flutter_resizable_container.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(ResizableChild, () {
+    group('equality', () {
+      test('equal when size, divider, and child are equal', () {
+        const child = SizedBox();
+        const a = ResizableChild(child: child);
+        const b = ResizableChild(child: child);
+        expect(a, equals(b));
+      });
+
+      test('not equal when divider differs', () {
+        const a = ResizableChild(
+          child: SizedBox(),
+          divider: ResizableDivider(thickness: 1),
+        );
+        const b = ResizableChild(
+          child: SizedBox(),
+          divider: ResizableDivider(thickness: 2),
+        );
+        expect(a, isNot(equals(b)));
+      });
+
+      test('not equal when divider color differs', () {
+        const a = ResizableChild(
+          child: SizedBox(),
+          divider: ResizableDivider(color: Color(0xFF000000)),
+        );
+        const b = ResizableChild(
+          child: SizedBox(),
+          divider: ResizableDivider(color: Color(0xFFFFFFFF)),
+        );
+        expect(a, isNot(equals(b)));
+      });
+
+      test('not equal when distinct keyless children of same type differ', () {
+        final a = ResizableChild(child: Text('one'));
+        final b = ResizableChild(child: Text('two'));
+        expect(a, isNot(equals(b)));
+      });
+
+      test('not equal when size differs', () {
+        const a = ResizableChild(
+          child: SizedBox(),
+          size: ResizableSize.pixels(100),
+        );
+        const b = ResizableChild(
+          child: SizedBox(),
+          size: ResizableSize.pixels(200),
+        );
+        expect(a, isNot(equals(b)));
+      });
+    });
+  });
+}

--- a/test/resizable_container_update_test.dart
+++ b/test/resizable_container_update_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_resizable_container/flutter_resizable_container.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _harness({
+  required ResizableController controller,
+  required ResizableDivider divider,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 600,
+        height: 400,
+        child: ResizableContainer(
+          controller: controller,
+          direction: Axis.horizontal,
+          children: [
+            ResizableChild(
+              size: const ResizableSize.pixels(200),
+              divider: divider,
+              child: const ColoredBox(color: Color(0xFF0000FF)),
+            ),
+            const ResizableChild(
+              child: ColoredBox(color: Color(0xFFFF0000)),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('ResizableContainer non-structural rebuild', () {
+    testWidgets('preserves hidden state when only divider config changes',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(600, 400));
+      final controller = ResizableController();
+
+      await tester.pumpWidget(
+        _harness(
+          controller: controller,
+          divider: const ResizableDivider(color: Color(0xFF111111)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      controller.hide(0);
+      await tester.pumpAndSettle();
+      expect(controller.isHidden(0), isTrue);
+
+      await tester.pumpWidget(
+        _harness(
+          controller: controller,
+          divider: const ResizableDivider(color: Color(0xFF222222)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        controller.isHidden(0),
+        isTrue,
+        reason: 'hidden state should survive a divider-only rebuild',
+      );
+    });
+
+    testWidgets(
+        'preserves saved hidden size when only the child widget instance '
+        'changes', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 400));
+      final controller = ResizableController();
+
+      Widget build(String label) => MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 1000,
+                height: 400,
+                child: ResizableContainer(
+                  controller: controller,
+                  direction: Axis.horizontal,
+                  children: [
+                    const ResizableChild(
+                      size: ResizableSize.pixels(300),
+                      child: ColoredBox(color: Color(0xFF0000FF)),
+                    ),
+                    ResizableChild(
+                      child: Text(label, key: const Key('label')),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+
+      await tester.pumpWidget(build('first'));
+      await tester.pumpAndSettle();
+
+      controller.hide(0);
+      await tester.pumpAndSettle();
+      expect(controller.isHidden(0), isTrue);
+
+      await tester.pumpWidget(build('second'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('second'), findsOneWidget);
+      expect(
+        controller.isHidden(0),
+        isTrue,
+        reason: 'hidden state should survive a child-only rebuild',
+      );
+
+      controller.show(0);
+      await tester.pumpAndSettle();
+      expect(
+        controller.pixels[0],
+        closeTo(300, 1),
+        reason: 'saved size from before the rebuild should be restored',
+      );
+    });
+
+    testWidgets('still resets state when the number of children changes',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(600, 400));
+      final controller = ResizableController();
+
+      Widget build(int count) => MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 600,
+                height: 400,
+                child: ResizableContainer(
+                  controller: controller,
+                  direction: Axis.horizontal,
+                  children: [
+                    for (var i = 0; i < count; i++)
+                      ResizableChild(
+                        child: ColoredBox(color: Color(0xFF000000 + i * 100)),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          );
+
+      await tester.pumpWidget(build(2));
+      await tester.pumpAndSettle();
+
+      controller.hide(0);
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(build(3));
+      await tester.pumpAndSettle();
+
+      expect(controller.hiddenIndices, isEmpty,
+          reason: 'structural change should reset hidden state');
+      expect(controller.pixels.length, equals(3));
+    });
+  });
+}

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -191,23 +191,19 @@ void main() {
 
     group('#setChildren', () {
       test('sets the list of ResizableChild', () {
-        controller.setChildren(const [
+        const child = SizedBox.shrink();
+        const children = [
           ResizableChild(
             size: ResizableSize.pixels(100),
-            child: SizedBox.shrink(),
+            child: child,
           ),
-        ]);
+        ];
+
+        controller.setChildren(children);
 
         expect(
           ResizableControllerTestHelper.getChildren(controller),
-          equals(
-            const [
-              ResizableChild(
-                size: ResizableSize.pixels(100),
-                child: SizedBox.shrink(),
-              ),
-            ],
-          ),
+          equals(children),
         );
       });
 


### PR DESCRIPTION
## Summary

Closes #105.

`ResizableChild.props` previously used `[size, child.key, child.runtimeType]`, which dropped `divider` entirely and reduced the child to its runtime type. As a result:

- Updates to a divider's config (color, thickness, callbacks) were silently ignored by `listEquals` in `ResizableContainer.didUpdateWidget`.
- Two distinct keyless widgets of the same runtime type (e.g. two different `Text`s) compared equal, masking child updates.

While fixing the props alone, a second bug surfaced: `ResizableContainer.didUpdateWidget` routed any inequality through `ResizableController.setChildren`, which clears `_pixels`, `_hiddenIndices`, and `_savedSizes`. Once the props become accurate, every parent rebuild that mutates a divider callback or creates fresh child widget instances would wipe panel sizes and re-show hidden panels.

This PR is split into two commits so each is independently bisect-friendly:

1. **`fix: preserve controller state on non-structural rebuilds`** — `didUpdateWidget` now distinguishes structural changes (different length or any declared `size`) from config changes (divider/child only). Structural changes keep the existing `setChildren` reset; config changes rebind `_children` via a new non-destructive `_updateChildrenInPlace`.
2. **`fix: include divider and child in ResizableChild.props (#105)`** — switches props to `[size, divider, child]`.

## Test plan

- [x] `test/resizable_child_test.dart` — equality covers divider and child differences and the default-equal case.
- [x] `test/resizable_container_update_test.dart` — hidden state survives a divider-only rebuild, hidden state + saved size survive a child-only rebuild, structural change (child count) still resets state.
- [x] Existing suite: 116 / 116 passing.