### PR TITLE
fix: include min/max in ResizableSize equality (#104)

### DIFF
--- a/lib/src/resizable_size.dart
+++ b/lib/src/resizable_size.dart
@@ -76,10 +76,13 @@ final class ResizableSizePixels extends ResizableSize {
 
   @override
   operator ==(Object other) =>
-      other is ResizableSizePixels && other.pixels == pixels;
+      other is ResizableSizePixels &&
+      other.pixels == pixels &&
+      other.min == min &&
+      other.max == max;
 
   @override
-  int get hashCode => pixels.hashCode;
+  int get hashCode => Object.hash(pixels, min, max);
 }
 
 final class ResizableSizeRatio extends ResizableSize {
@@ -95,10 +98,13 @@ final class ResizableSizeRatio extends ResizableSize {
 
   @override
   operator ==(Object other) =>
-      other is ResizableSizeRatio && other.ratio == ratio;
+      other is ResizableSizeRatio &&
+      other.ratio == ratio &&
+      other.min == min &&
+      other.max == max;
 
   @override
-  int get hashCode => ratio.hashCode;
+  int get hashCode => Object.hash(ratio, min, max);
 }
 
 final class ResizableSizeExpand extends ResizableSize {
@@ -113,10 +119,13 @@ final class ResizableSizeExpand extends ResizableSize {
 
   @override
   operator ==(Object other) =>
-      other is ResizableSizeExpand && other.flex == flex;
+      other is ResizableSizeExpand &&
+      other.flex == flex &&
+      other.min == min &&
+      other.max == max;
 
   @override
-  int get hashCode => flex.hashCode;
+  int get hashCode => Object.hash(flex, min, max);
 }
 
 final class ResizableSizeShrink extends ResizableSize {
@@ -124,4 +133,11 @@ final class ResizableSizeShrink extends ResizableSize {
 
   @override
   String toString() => 'ResizableSizeShrink()';
+
+  @override
+  operator ==(Object other) =>
+      other is ResizableSizeShrink && other.min == min && other.max == max;
+
+  @override
+  int get hashCode => Object.hash(min, max);
 }

--- a/test/resizable_controller_test.dart
+++ b/test/resizable_controller_test.dart
@@ -501,7 +501,10 @@ void main() {
 
         expect(controller.isHidden(1), isTrue);
         expect(controller.hiddenIndices, equals({1}));
-        expect(controller.sizes[1], equals(const ResizableSize.pixels(0)));
+        expect(
+          controller.sizes[1],
+          equals(const ResizableSize.pixels(0, min: 0, max: 0)),
+        );
         expect(controller.needsLayout, isTrue);
       });
 
@@ -558,7 +561,10 @@ void main() {
         ]);
 
         // hidden index still zero-sized
-        expect(controller.sizes[1], equals(const ResizableSize.pixels(0)));
+        expect(
+          controller.sizes[1],
+          equals(const ResizableSize.pixels(0, min: 0, max: 0)),
+        );
         expect(controller.isHidden(1), isTrue);
 
         controller.show(1);

--- a/test/resizable_size_test.dart
+++ b/test/resizable_size_test.dart
@@ -55,6 +55,149 @@ void main() {
             isFalse,
           );
         });
+
+        group('pixels', () {
+          test('returns false when min differs', () {
+            expect(
+              const ResizableSize.pixels(1, min: 10) ==
+                  const ResizableSize.pixels(1, min: 20),
+              isFalse,
+            );
+          });
+
+          test('returns false when max differs', () {
+            expect(
+              const ResizableSize.pixels(1, max: 100) ==
+                  const ResizableSize.pixels(1, max: 200),
+              isFalse,
+            );
+          });
+
+          test('returns true when pixels, min, and max all match', () {
+            expect(
+              const ResizableSize.pixels(1, min: 10, max: 100) ==
+                  const ResizableSize.pixels(1, min: 10, max: 100),
+              isTrue,
+            );
+          });
+
+          test('hashCode differs when min/max differ', () {
+            expect(
+              const ResizableSize.pixels(1, min: 10).hashCode ==
+                  const ResizableSize.pixels(1, min: 20).hashCode,
+              isFalse,
+            );
+          });
+        });
+
+        group('ratio', () {
+          test('returns false when min differs', () {
+            expect(
+              const ResizableSize.ratio(0.5, min: 10) ==
+                  const ResizableSize.ratio(0.5, min: 20),
+              isFalse,
+            );
+          });
+
+          test('returns false when max differs', () {
+            expect(
+              const ResizableSize.ratio(0.5, max: 100) ==
+                  const ResizableSize.ratio(0.5, max: 200),
+              isFalse,
+            );
+          });
+
+          test('returns true when ratio, min, and max all match', () {
+            expect(
+              const ResizableSize.ratio(0.5, min: 10, max: 100) ==
+                  const ResizableSize.ratio(0.5, min: 10, max: 100),
+              isTrue,
+            );
+          });
+
+          test('hashCode differs when min/max differ', () {
+            expect(
+              const ResizableSize.ratio(0.5, min: 10).hashCode ==
+                  const ResizableSize.ratio(0.5, min: 20).hashCode,
+              isFalse,
+            );
+          });
+        });
+
+        group('expand', () {
+          test('returns false when min differs', () {
+            expect(
+              const ResizableSize.expand(min: 10) ==
+                  const ResizableSize.expand(min: 20),
+              isFalse,
+            );
+          });
+
+          test('returns false when max differs', () {
+            expect(
+              const ResizableSize.expand(max: 100) ==
+                  const ResizableSize.expand(max: 200),
+              isFalse,
+            );
+          });
+
+          test('returns true when flex, min, and max all match', () {
+            expect(
+              const ResizableSize.expand(flex: 2, min: 10, max: 100) ==
+                  const ResizableSize.expand(flex: 2, min: 10, max: 100),
+              isTrue,
+            );
+          });
+
+          test('hashCode differs when min/max differ', () {
+            expect(
+              const ResizableSize.expand(min: 10).hashCode ==
+                  const ResizableSize.expand(min: 20).hashCode,
+              isFalse,
+            );
+          });
+        });
+
+        group('shrink', () {
+          test('returns true for two default shrink instances', () {
+            expect(
+              const ResizableSize.shrink() == const ResizableSize.shrink(),
+              isTrue,
+            );
+          });
+
+          test('returns false when min differs', () {
+            expect(
+              const ResizableSize.shrink(min: 10) ==
+                  const ResizableSize.shrink(min: 20),
+              isFalse,
+            );
+          });
+
+          test('returns false when max differs', () {
+            expect(
+              const ResizableSize.shrink(max: 100) ==
+                  const ResizableSize.shrink(max: 200),
+              isFalse,
+            );
+          });
+
+          test('returns true when min and max match', () {
+            expect(
+              const ResizableSize.shrink(min: 10, max: 100) ==
+                  const ResizableSize.shrink(min: 10, max: 100),
+              isTrue,
+            );
+          });
+
+          test('hashCode matches for equal instances', () {
+            expect(
+              const ResizableSize.shrink(min: 10, max: 100).hashCode ==
+                  const ResizableSize.shrink(min: 10, max: 100).hashCode,
+              isTrue,
+            );
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary
- `ResizableSizePixels`, `ResizableSizeRatio`, and `ResizableSizeExpand` `==` / `hashCode` now include `min` and `max` (previously only the primary field was compared)
- `ResizableSizeShrink` gains its missing `==` / `hashCode` overrides (was falling back to identity)
- Updates two stale controller tests that compared the hidden-child size against `ResizableSize.pixels(0)` to compare against the actual hidden-size constant `ResizableSize.pixels(0, min: 0, max: 0)`

Fixes the bug where `listEquals(oldWidget.children, widget.children)` in `resizable_container.dart:59` failed to detect constraint changes, so the controller wouldn't relayout when only `min`/`max` differed.

Closes #104

## Test plan
- [x] All 139 existing + new equality tests pass (`flutter test`)
- [x] Added equality tests for all four subclasses covering `min`/`max` differences and `hashCode` consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)