### PR TITLE
feat: lock individual dividers or the whole container (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ Use the `ResizableDivider` class to customize the look and feel of the dividers 
 
 You can customize the `thickness`, `length`, `crossAxisAlignment`, `mainAxisAlignment`, and `color` of the divider, as well as display a custom mouse cursor on hover and respond to `onDragStart`, `onDragEnd`, `onHoverEnter`, `onHoverExit`, `onTapDown`, and `onTapUp` events.
 
+Set `enabled: false` to lock a single divider so it cannot be dragged, tapped, or hovered. To lock every divider in a container at once, pass `resizable: false` to the `ResizableContainer`. A divider is interactive only when both flags are `true`; programmatic resizing through `ResizableController` is unaffected in either case.
+
 ```dart
 divider: ResizableDivider(
     thickness: 2,

--- a/example/lib/screens/basic/basic_example_screen.dart
+++ b/example/lib/screens/basic/basic_example_screen.dart
@@ -6,8 +6,15 @@ import 'package:example/widgets/size_label.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 
-class BasicExampleScreen extends StatelessWidget {
+class BasicExampleScreen extends StatefulWidget {
   const BasicExampleScreen({super.key});
+
+  @override
+  State<BasicExampleScreen> createState() => _BasicExampleScreenState();
+}
+
+class _BasicExampleScreenState extends State<BasicExampleScreen> {
+  bool _locked = false;
 
   @override
   Widget build(BuildContext context) {
@@ -15,6 +22,11 @@ class BasicExampleScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Basic two-pane example'),
         actions: [
+          IconButton(
+            icon: Icon(_locked ? Icons.lock : Icons.lock_open),
+            tooltip: _locked ? 'Unlock divider' : 'Lock divider',
+            onPressed: () => setState(() => _locked = !_locked),
+          ),
           IconButton(
             icon: const Icon(Icons.help_center),
             onPressed: () => BasicExampleHelpDialog.show(context: context),
@@ -31,6 +43,7 @@ class BasicExampleScreen extends StatelessWidget {
       drawer: const NavDrawer(),
       body: ResizableContainer(
         direction: Axis.horizontal,
+        resizable: !_locked,
         children: [
           ResizableChild(
             child: ColoredBox(

--- a/lib/src/resizable_container.dart
+++ b/lib/src/resizable_container.dart
@@ -24,6 +24,7 @@ class ResizableContainer extends StatefulWidget {
     this.controller,
     this.cascadeNegativeDelta = false,
     this.hideAnimation,
+    this.resizable = true,
   });
 
   /// A list of [ResizableChild] containing the child [Widget]s and
@@ -50,6 +51,17 @@ class ResizableContainer extends StatefulWidget {
   /// [ResizableHideAnimation.curve]. Other size transitions (divider drag,
   /// [ResizableController.setSizes], available-space changes) remain instant.
   final ResizableHideAnimation? hideAnimation;
+
+  /// Whether dividers in this container respond to user input.
+  ///
+  /// When `false`, every divider is locked — drag, tap, and hover callbacks
+  /// will not fire and the resize cursor is not shown. Individual dividers
+  /// can also be locked via [ResizableDivider.enabled]; a divider is
+  /// interactive only when both this flag and its own `enabled` flag are
+  /// `true`. Programmatic resizing via [ResizableController] is unaffected.
+  ///
+  /// Defaults to `true`.
+  final bool resizable;
 
   @override
   State<ResizableContainer> createState() => _ResizableContainerState();
@@ -382,9 +394,11 @@ class _ResizableContainerState extends State<ResizableContainer>
     if (size == 0) {
       return const SizedBox.shrink();
     }
+    final config = widget.children[dividerIndex].divider;
     final divider = ResizableContainerDivider(
-      config: widget.children[dividerIndex].divider,
+      config: config,
       direction: widget.direction,
+      enabled: widget.resizable && config.enabled,
       onResizeUpdate: (delta) => manager.adjustChildSize(
         index: dividerIndex,
         delta: delta,

--- a/lib/src/resizable_container_divider.dart
+++ b/lib/src/resizable_container_divider.dart
@@ -13,17 +13,24 @@ class ResizableContainerDivider extends StatefulWidget {
     required this.direction,
     required this.config,
     required void Function(double) this.onResizeUpdate,
+    this.enabled = true,
   });
 
   const ResizableContainerDivider.placeholder({
     super.key,
     required this.config,
     required this.direction,
-  }) : onResizeUpdate = null;
+  })  : onResizeUpdate = null,
+        enabled = true;
 
   final Axis direction;
   final void Function(double)? onResizeUpdate;
   final ResizableDivider config;
+
+  /// Whether this divider responds to drag, tap, and hover input. When
+  /// `false`, gesture handlers and the resize cursor are suppressed; the
+  /// divider remains visible.
+  final bool enabled;
 
   @override
   State<ResizableContainerDivider> createState() =>
@@ -86,6 +93,9 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   }
 
   MouseCursor _getCursor() {
+    if (!widget.enabled) {
+      return widget.config.cursor ?? MouseCursor.defer;
+    }
     return switch (widget.direction) {
       Axis.horizontal =>
         widget.config.cursor ?? SystemMouseCursors.resizeLeftRight,
@@ -118,11 +128,13 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   }
 
   void _onEnter(PointerEnterEvent _) {
+    if (!widget.enabled) return;
     setState(() => isHovered = true);
     widget.config.onHoverEnter?.call();
   }
 
   void _onExit(PointerExitEvent _) {
+    if (!widget.enabled) return;
     setState(() => isHovered = false);
 
     if (!isDragging) {
@@ -131,6 +143,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   }
 
   void _onVerticalDragStart(DragStartDetails _) {
+    if (!widget.enabled) return;
     if (widget.direction == Axis.vertical) {
       setState(() => isDragging = true);
       widget.config.onDragStart?.call();
@@ -138,12 +151,14 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   }
 
   void _onVerticalDragUpdate(DragUpdateDetails details) {
+    if (!widget.enabled) return;
     if (widget.direction == Axis.vertical) {
       widget.onResizeUpdate?.call(details.delta.dy);
     }
   }
 
   void _onVerticalDragEnd(DragEndDetails _) {
+    if (!widget.enabled) return;
     if (widget.direction == Axis.vertical) {
       setState(() => isDragging = false);
       widget.config.onDragEnd?.call();
@@ -155,6 +170,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   }
 
   void _onHorizontalDragStart(DragStartDetails _) {
+    if (!widget.enabled) return;
     if (widget.direction == Axis.horizontal) {
       setState(() => isDragging = true);
       widget.config.onDragStart?.call();
@@ -165,6 +181,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
     TextDirection textDirection,
   ) {
     return (details) {
+      if (!widget.enabled) return;
       if (widget.direction == Axis.horizontal) {
         final delta = details.delta.dx;
 
@@ -177,6 +194,7 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   }
 
   void _onHorizontalDragEnd(DragEndDetails _) {
+    if (!widget.enabled) return;
     if (widget.direction == Axis.horizontal) {
       setState(() => isDragging = false);
       widget.config.onDragEnd?.call();
@@ -188,10 +206,12 @@ class _ResizableContainerDividerState extends State<ResizableContainerDivider> {
   }
 
   void _onTapDown(TapDownDetails _) {
+    if (!widget.enabled) return;
     widget.config.onTapDown?.call();
   }
 
   void _onTapUp(TapUpDetails _) {
+    if (!widget.enabled) return;
     widget.config.onTapUp?.call();
   }
 }

--- a/lib/src/resizable_divider.dart
+++ b/lib/src/resizable_divider.dart
@@ -17,6 +17,7 @@ class ResizableDivider extends Equatable {
     this.cursor,
     this.mainAxisAlignment = MainAxisAlignment.center,
     this.crossAxisAlignment = CrossAxisAlignment.center,
+    this.enabled = true,
   })  : assert(thickness > 0, '[thickness] must be > 0.'),
         assert(
           length is! ResizableSizeShrink,
@@ -84,6 +85,17 @@ class ResizableDivider extends Equatable {
   /// The cursor to display when hovering over this divider.
   final MouseCursor? cursor;
 
+  /// Whether this divider is interactive.
+  ///
+  /// When `false`, the divider is rendered but cannot be dragged, tapped, or
+  /// hovered — its drag, tap, and hover callbacks will not fire and the
+  /// resize cursor is not shown. Programmatic resizing via
+  /// [ResizableController] is unaffected.
+  ///
+  /// Defaults to `true`. See also [ResizableContainer.resizable], which
+  /// disables every divider in the container at once.
+  final bool enabled;
+
   @override
   List<Object?> get props => [
         thickness,
@@ -97,5 +109,6 @@ class ResizableDivider extends Equatable {
         cursor,
         mainAxisAlignment,
         crossAxisAlignment,
+        enabled,
       ];
 }

--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -2161,6 +2161,101 @@ void main() {
         expect(notifies, 2);
       });
     });
+
+    group('resizable', () {
+      testWidgets(
+        'locks every divider when false',
+        (tester) async {
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.binding.setSurfaceSize(const Size(600, 100));
+          addTearDown(() async => await tester.binding.setSurfaceSize(null));
+
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: ResizableContainer(
+                  controller: controller,
+                  direction: Axis.horizontal,
+                  resizable: false,
+                  children: const [
+                    ResizableChild(
+                      size: ResizableSize.ratio(0.33),
+                      child: SizedBox.expand(),
+                    ),
+                    ResizableChild(
+                      size: ResizableSize.ratio(0.33),
+                      child: SizedBox.expand(),
+                    ),
+                    ResizableChild(
+                      size: ResizableSize.ratio(0.34),
+                      child: SizedBox.expand(),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final beforeSizes = List<double>.of(controller.pixels);
+          final dividers = find.byType(ResizableContainerDivider);
+          expect(dividers, findsNWidgets(2));
+
+          await tester.drag(dividers.first, const Offset(80, 0));
+          await tester.pumpAndSettle();
+          await tester.drag(dividers.last, const Offset(-80, 0));
+          await tester.pumpAndSettle();
+
+          expect(controller.pixels, beforeSizes);
+        },
+      );
+
+      testWidgets(
+        'programmatic resize still works when false',
+        (tester) async {
+          final controller = ResizableController();
+          addTearDown(controller.dispose);
+
+          await tester.binding.setSurfaceSize(const Size(600, 100));
+          addTearDown(() async => await tester.binding.setSurfaceSize(null));
+
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: ResizableContainer(
+                  controller: controller,
+                  direction: Axis.horizontal,
+                  resizable: false,
+                  children: const [
+                    ResizableChild(
+                      size: ResizableSize.ratio(0.5),
+                      child: SizedBox.expand(),
+                    ),
+                    ResizableChild(
+                      size: ResizableSize.ratio(0.5),
+                      child: SizedBox.expand(),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          controller.setSizes(const [
+            ResizableSize.ratio(0.25),
+            ResizableSize.ratio(0.75),
+          ]);
+          await tester.pumpAndSettle();
+
+          const available = 600 - 1;
+          expect(controller.pixels[0], closeTo(available * 0.25, 0.001));
+          expect(controller.pixels[1], closeTo(available * 0.75, 0.001));
+        },
+      );
+    });
   });
 }
 

--- a/test/resizable_divider_test.dart
+++ b/test/resizable_divider_test.dart
@@ -254,6 +254,106 @@ void main() {
       });
     });
 
+    group('enabled', () {
+      testWidgets('suppresses drag-driven resizing when false', (tester) async {
+        final controller = ResizableController();
+        addTearDown(controller.dispose);
+
+        await tester.binding.setSurfaceSize(const Size(400, 100));
+        addTearDown(() async => await tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ResizableContainer(
+                controller: controller,
+                direction: Axis.horizontal,
+                children: const [
+                  ResizableChild(
+                    size: ResizableSize.ratio(0.5),
+                    divider: ResizableDivider(enabled: false),
+                    child: SizedBox.expand(),
+                  ),
+                  ResizableChild(
+                    size: ResizableSize.ratio(0.5),
+                    child: SizedBox.expand(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final beforeSizes = List<double>.of(controller.pixels);
+        final divider = find.byType(ResizableContainerDivider);
+
+        await tester.drag(divider, const Offset(50, 0));
+        await tester.pumpAndSettle();
+
+        expect(controller.pixels, beforeSizes);
+      });
+
+      testWidgets('suppresses tap, hover, and drag callbacks when false',
+          (tester) async {
+        var hoverEnter = false;
+        var hoverExit = false;
+        var tappedDown = false;
+        var tappedUp = false;
+        var dragStarted = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ResizableContainer(
+                controller: ResizableController(),
+                direction: Axis.horizontal,
+                children: [
+                  ResizableChild(
+                    divider: ResizableDivider(
+                      enabled: false,
+                      onHoverEnter: () => hoverEnter = true,
+                      onHoverExit: () => hoverExit = true,
+                      onTapDown: () => tappedDown = true,
+                      onTapUp: () => tappedUp = true,
+                      onDragStart: () => dragStarted = true,
+                    ),
+                    child: const SizedBox.expand(),
+                  ),
+                  const ResizableChild(child: SizedBox.expand()),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final divider = find.byType(ResizableContainerDivider);
+
+        final gesture =
+            await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await gesture.addPointer(location: Offset.zero);
+        addTearDown(() => gesture.removePointer());
+        await tester.pump();
+        await gesture.moveTo(tester.getCenter(divider));
+        await tester.pumpAndSettle();
+        await gesture.moveTo(Offset.zero);
+        await tester.pumpAndSettle();
+
+        await tester.tap(divider, kind: PointerDeviceKind.touch);
+        await tester.pumpAndSettle();
+
+        await tester.drag(divider, const Offset(40, 0));
+        await tester.pumpAndSettle();
+
+        expect(hoverEnter, isFalse);
+        expect(hoverExit, isFalse);
+        expect(tappedDown, isFalse);
+        expect(tappedUp, isFalse);
+        expect(dragStarted, isFalse);
+      });
+    });
+
     group('onTapUp', () {
       testWidgets('fires when the divider tap is released', (tester) async {
         bool tappedUp = false;


### PR DESCRIPTION
## Summary
Closes #73.

Adds two interaction-locking surfaces (both default `true`, fully back-compat):

- `ResizableDivider.enabled` — locks a single divider.
- `ResizableContainer.resizable` — locks every divider in the container at once.

A divider is interactive only when both flags are `true`. When locked, drag/tap/hover handlers and the resize cursor are suppressed; the divider remains visually present. Programmatic resizing via `ResizableController` is unaffected.

Implementation notes:
- `ResizableContainerDivider` takes a separate `enabled` parameter so the existing placeholder constructor's `onResizeUpdate == null` signal stays distinct from "locked."
- Effective enabled state is recomputed each build in `_buildDividerSlot`, so toggling either flag at runtime works without controller invalidation.
- Cursor falls back to `MouseCursor.defer` when locked, so any underlying cursor shows through; otherwise the configured `cursor` still wins.
- `enabled` is included in `ResizableDivider.props` so `listEquals` and the in-place update path notice config-only flips.

## Test plan
- [x] `dart analyze` clean
- [x] `very_good test` passes
- [x] New tests: per-divider drag suppression, per-divider tap/hover/drag callback suppression, container-wide drag suppression on multiple dividers, programmatic `setSizes` still works when `resizable: false`
- [x] Manual sanity check in the example app

🤖 Generated with [Claude Code](https://claude.com/claude-code)