### PR TITLE
test: pin controller notify count for layout cycle (#122)

### DIFF
--- a/test/resizable_container_test.dart
+++ b/test/resizable_container_test.dart
@@ -2071,6 +2071,96 @@ void main() {
         },
       );
     });
+
+    group('notify count', () {
+      // The container schedules a post-frame setRenderedSizes after every
+      // layout pass. That callback notifies controller listeners so the
+      // build path can switch from the layout widget (with placeholder
+      // dividers) to the flex widget (with interactive dividers). These
+      // tests pin the resulting notification count so a future refactor
+      // can't silently introduce another redundant notify cycle.
+      testWidgets('initial mount notifies exactly once', (tester) async {
+        await tester.binding.setSurfaceSize(const Size(600, 400));
+        final controller = ResizableController();
+        addTearDown(controller.dispose);
+
+        var notifies = 0;
+        controller.addListener(() => notifies++);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ResizableContainer(
+                controller: controller,
+                direction: Axis.horizontal,
+                children: const [
+                  ResizableChild(
+                    size: ResizableSize.expand(),
+                    child: SizedBox.expand(key: Key('A')),
+                  ),
+                  ResizableChild(
+                    size: ResizableSize.pixels(200),
+                    child: SizedBox.expand(key: Key('B')),
+                  ),
+                  ResizableChild(
+                    size: ResizableSize.expand(),
+                    child: SizedBox.expand(key: Key('C')),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Exactly one notify: the post-frame setRenderedSizes that
+        // populates controller.pixels and switches the build path.
+        expect(notifies, 1);
+      });
+
+      testWidgets('hide produces exactly two notifies', (tester) async {
+        await tester.binding.setSurfaceSize(const Size(600, 400));
+        final controller = ResizableController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: ResizableContainer(
+                controller: controller,
+                direction: Axis.horizontal,
+                children: const [
+                  ResizableChild(
+                    size: ResizableSize.expand(),
+                    child: SizedBox.expand(key: Key('A')),
+                  ),
+                  ResizableChild(
+                    size: ResizableSize.pixels(200),
+                    child: SizedBox.expand(key: Key('B')),
+                  ),
+                  ResizableChild(
+                    size: ResizableSize.expand(),
+                    child: SizedBox.expand(key: Key('C')),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        var notifies = 0;
+        controller.addListener(() => notifies++);
+
+        controller.hide(1);
+        await tester.pumpAndSettle();
+
+        // Two notifies: one from setHidden (sizes/hiddenIndices changed)
+        // and one from the post-frame setRenderedSizes (rendered pixels
+        // changed and the build path switches back to the flex layout).
+        expect(notifies, 2);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

Closes #122.

The issue asked whether the post-frame `setRenderedSizes` notify could be elided to avoid a layout retrigger. Investigation shows the notify is **structurally required**, not wasted:

- It triggers the build-path switch in `_buildForPhase` from `ResizableLayout` (placeholder, non-interactive dividers) to `Flex` (interactive dividers with `onResizeUpdate`). Without it, dividers can't be dragged after the first layout.
- `notifyListeners()` triggers `markNeedsBuild`, which is illegal during `performLayout`, so the post-frame defer is required.
- `controller.pixels` is public API — user listeners legitimately expect to be notified when rendered pixels populate.
- `_needsLayout = false` is set before the notify, so the resulting rebuild takes the Flex path and never re-enters layout. The "re-trigger" risk is already short-circuited.

Empirical measurement: **1 notify on initial mount, 2 notifies per `hide()`** (one from `setHidden`, one from the post-frame `setRenderedSizes`). Both convey real state changes.

No `lib/` changes. Adds two regression tests under a new `notify count` group that pin the cadence — a future refactor that accidentally adds a third notify or removes the load-bearing one will fail.

## Test plan

- [x] `initial mount notifies exactly once`
- [x] `hide produces exactly two notifies`
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)