### PR TITLE
ci: add pub.dev publishing workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,14 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yaml` that publishes the package to pub.dev when a `v*` tag is pushed or a GitHub release is published.
- Uses `dart-lang/setup-dart/.github/workflows/publish.yml@v1` with OIDC (`id-token: write`) — no pub.dev credentials stored as repo secrets.
- Pairs with the existing release-please workflow, which produces the `v<version>` tag and release on merge of its release PR.

## Required setup (already done)
- pub.dev package admin → Automated publishing → GitHub repo `andyhorn/flutter_resizable_container`, tag pattern `v{{version}}`.

## Test plan
- [ ] Merge this PR.
- [ ] On the next release-please release PR merge, confirm the `Publish to pub.dev` workflow runs against the `v<version>` tag and the new version appears on pub.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)