### PR TITLE
perf: replace Decimal arithmetic in expand layout with doubles (#121)

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -65,14 +65,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
-  decimal:
-    dependency: transitive
-    description:
-      name: decimal
-      sha256: fc706a5618b81e5b367b01dd62621def37abc096f2b46a9bd9068b64c1fa36d0
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.4"
   equatable:
     dependency: transitive
     description:
@@ -175,14 +167,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.20.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -295,14 +279,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  rational:
-    dependency: transitive
-    description:
-      name: rational
-      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.3"
   record_use:
     dependency: transitive
     description:

--- a/lib/src/extensions/num_ext.dart
+++ b/lib/src/extensions/num_ext.dart
@@ -1,9 +1,3 @@
-import 'package:decimal/decimal.dart';
-
-extension DoubleExtensions on double {
-  Decimal toDecimal() => Decimal.parse(toString());
-}
-
 extension ListDoubleExtensions on Iterable<double> {
   double sum() => fold(0.0, (sum, curr) => sum + curr);
 }

--- a/lib/src/layout/resizable_layout.dart
+++ b/lib/src/layout/resizable_layout.dart
@@ -1,4 +1,3 @@
-import 'package:decimal/decimal.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -173,7 +172,7 @@ class ResizableLayoutRenderObject extends RenderBox
       final constraints = switch (size) {
         ResizableSizeExpand() => layoutDirection.copyConstraintsWith(
             this.constraints,
-            expandSizes[i ~/ 2]!.toDouble(),
+            expandSizes[i ~/ 2]!,
           ),
         _ => _getChildConstraints(
             size: size,
@@ -200,57 +199,53 @@ class ResizableLayoutRenderObject extends RenderBox
     onComplete(finalSizes);
   }
 
-  Map<int, Decimal> _getExpandSizes(double availableSpace) {
+  Map<int, double> _getExpandSizes(double availableSpace) {
     bool isExpand(ResizableSize size) => size is ResizableSizeExpand;
 
-    var expandIndices = _sizes.indicesWhere(isExpand).toList();
+    final expandIndices = _sizes.indicesWhere(isExpand).toList();
 
     if (expandIndices.isEmpty) {
       return {};
     }
 
-    final allocatedSpace = Map<int, Decimal>.fromIterable(
-      expandIndices,
-      value: (_) => Decimal.zero,
-    );
+    final allocatedSpace = <int, double>{
+      for (final index in expandIndices) index: 0.0,
+    };
 
-    var remainingFlex = _getFlexCount().toDecimal();
-    var remainingSpace = availableSpace.toDecimal();
-    var shouldContinue = true;
+    var remainingFlex = _getFlexCount();
+    var remainingSpace = availableSpace;
 
-    do {
+    // Bounded to defend against floating-point residue that could otherwise
+    // keep `didChange` true forever. Each pass either removes at least one
+    // clamped item or makes a final redistribution; the natural termination
+    // pass adds one more iteration.
+    final maxIterations = expandIndices.length + 2;
+
+    for (var iter = 0; iter < maxIterations && remainingFlex > 0; iter++) {
       var didChange = false;
       final toRemove = <int>[];
-      final targetDeltaPerFlex = (remainingSpace / remainingFlex).toDecimal(
-        scaleOnInfinitePrecision: 6,
-      );
+      final perFlex = remainingSpace / remainingFlex;
 
       for (final index in expandIndices) {
-        final size = _sizes[index];
+        final size = _sizes[index] as ResizableSizeExpand;
+        final currentValue = allocatedSpace[index]!;
+        final targetSize = currentValue + perFlex * size.flex;
+        final clampedValue = _clamp(targetSize, size);
 
-        if (size is ResizableSizeExpand) {
-          final flex = size.flex.toDecimal();
-          final currentValue = allocatedSpace[index] ?? Decimal.zero;
-          final targetDelta = targetDeltaPerFlex * flex;
-          final targetSize = (currentValue + targetDelta).toDouble();
-          final clampedValue = _clamp(targetSize, size).toDecimal();
-
-          if (clampedValue != currentValue) {
-            final difference = clampedValue - currentValue;
-            remainingSpace -= difference;
-            allocatedSpace[index] = clampedValue;
-            didChange = true;
-          } else {
-            remainingFlex -= flex;
-            toRemove.add(index);
-          }
+        if (clampedValue != currentValue) {
+          remainingSpace -= clampedValue - currentValue;
+          allocatedSpace[index] = clampedValue;
+          didChange = true;
+        } else {
+          remainingFlex -= size.flex;
+          toRemove.add(index);
         }
       }
 
       expandIndices.removeWhere(toRemove.contains);
 
-      shouldContinue = didChange && remainingFlex > Decimal.zero;
-    } while (shouldContinue);
+      if (!didChange) break;
+    }
 
     return allocatedSpace;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  decimal: ^3.2.4
   equatable: ^2.0.8
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Replaces `Decimal` math in `_getExpandSizes` with native double arithmetic. The Decimal-based loop ran `Decimal.parse(toString())` conversions on every layout pass and allocated on every operation; pixel layout doesn't need rational precision.
- Algorithm structure (iterative clamp + redistribute) is unchanged. Iteration is bounded by `expandIndices.length + 2` to defend against FP residue keeping `didChange=true`.
- Drops the `decimal` dependency from `pubspec.yaml` and removes the now-unused `toDecimal()` extension.

Closes #121.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — all tests pass (expand math tests use exactly-representable values: 198, 398, 300, 100, 500; no rounding fixup needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)